### PR TITLE
feat: TB-Bridge (userspace tensor offload) + Mac RDMA protocol capture toolkit

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,110 @@
+# TB-Bridge — userspace tensor offload over Thunderbolt IP
+
+A pure-Python client/server that lets a Linux CUDA training host offload
+tensors to a Mac (or any peer) across a Thunderbolt 5 cable, using the
+ordinary IP-over-Thunderbolt stack Apple already ships.
+
+## What this is — and isn't
+
+**It is**: a working userspace bridge usable today. ~25–40 Gbps over TB5
+IP, ~50–200 µs round-trip latency. Suitable as an offload tier for spilled
+tensors when the training GPU's VRAM isn't big enough.
+
+**It isn't**: GPU-direct RDMA. Data goes through host RAM on both ends.
+For zero-copy GPU-to-GPU over Thunderbolt you need OdinLink's kernel
+driver path (Linux↔Linux working today, Mac interop work-in-progress;
+see [`../docs/MAC_PROTOCOL_CAPTURE.md`](../docs/MAC_PROTOCOL_CAPTURE.md)
+and [`../docs/REMOTE_TENSORS.md`](../docs/REMOTE_TENSORS.md)).
+
+## Quick start
+
+### On the Mac (or remote host)
+
+```bash
+# Find your TB-net IP — Apple assigns one when the cable is connected:
+ifconfig | grep -A 3 bridge   # look for an "inet" line under a TB-named iface
+# Or check System Settings → Network → "Thunderbolt Bridge"
+
+python3 bridge/tb_bridge_server.py --bind 0.0.0.0 --max-gb 96 -v
+```
+
+### On the Linux training host
+
+```bash
+# Quick benchmark
+python3 bridge/benchmark.py --host <mac-tb-ip> --cuda
+
+# Programmatic use
+python3 -c '
+import torch
+from bridge.tb_bridge_client import TBBridgeClient
+
+cli = TBBridgeClient("10.0.0.2")          # mac TB-net IP
+x = torch.randn(1024, 4096, dtype=torch.bfloat16, device="cuda")
+cli.put("layer.42.attn", x)               # offload to mac
+y = cli.get("layer.42.attn", device="cuda")  # fetch back
+assert torch.equal(x, y)
+print("round-trip OK")
+'
+```
+
+## Wire protocol
+
+Length-prefixed binary over TCP, one request per connection. All integers
+big-endian.
+
+```
+Request:
+  u8   op           PUT=1, GET=2, DEL=3, LIST=4, STAT=5
+  u32  key_len
+  u8[] key          (≤256 B utf-8)
+  PUT only:
+    u32  meta_len
+    u8[] meta_json  (dtype, shape, kind: numpy|torch)
+    u64  data_len
+    u8[] data       (raw tensor bytes)
+
+Response:
+  u8   status       0=OK, 1=NOT_FOUND, 2=BAD_OP, 3=OOM, 4=PROTOCOL
+  GET only (status=OK):
+    u32  meta_len
+    u8[] meta_json
+    u64  data_len
+    u8[] data
+  LIST only (status=OK):
+    u32  n
+    n × ( u32 keylen + u8[] key )
+  STAT only (status=OK):
+    u64  total_bytes
+    u32  num_keys
+```
+
+## bfloat16 caveat
+
+NumPy has no native bf16. The client carries bf16 tensors as `uint16` on
+the wire and rehydrates them with `tensor.view(torch.bfloat16)` on the
+receive side. Lossless.
+
+## Performance ceiling
+
+Theoretical TB5 IP layer: 80 Gbps raw → ~10 GB/s payload after framing.
+Real-world over Apple's bridge: 25–40 Gbps (~3–5 GB/s). Latency floor:
+the TCP stack + scheduler costs ~50 µs each direction. So this is best
+for tensors ≥ 16 MB; smaller payloads spend most of their time in
+syscall overhead.
+
+For comparison: a single PCIe Gen4 x16 link is ~64 GB/s, so the bridge
+is roughly 5–15× slower than local VRAM movement. The win is *capacity*,
+not bandwidth: it lets you treat the Mac's 96–192 GB unified memory as
+an extension of the training host's spill pool.
+
+## What's missing
+
+- **Connection reuse**: every operation opens a fresh socket. Fine for
+  bulk transfers, painful for tight loops with sub-MB tensors.
+- **Compression**: bf16 + lz4 would help if you're often offloading
+  near-zero activations. Out of scope for v1.
+- **Encryption**: zero. Run it on a private link only.
+- **MLX zero-copy**: Mac side should be able to import the resident buffer
+  into an `mlx.array` without a copy (unified memory). Hook stub exists
+  but not yet wired (`mlx_helpers.py`).

--- a/bridge/benchmark.py
+++ b/bridge/benchmark.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""TB-Bridge bandwidth + latency benchmark.
+
+Run the server first:
+    # on Mac (or any host across the TB5 cable):
+    python3 bridge/tb_bridge_server.py --bind 0.0.0.0 -v
+
+Then on the Linux/CUDA training host:
+    python3 bridge/benchmark.py --host <mac-tb-net-ip>
+
+Reports:
+    - PUT bandwidth (host RAM → server RAM)
+    - GET bandwidth (server RAM → host RAM)
+    - Small-payload round-trip latency
+    - If torch+CUDA available: PUT/GET against CUDA tensors
+"""
+import argparse
+import statistics
+import time
+
+import numpy as np
+
+try:
+    import torch
+    _HAS_CUDA = torch.cuda.is_available()
+except ImportError:
+    _HAS_CUDA = False
+
+from tb_bridge_client import TBBridgeClient
+
+
+def bench_bandwidth(cli, size_bytes: int, iters: int, label: str, use_cuda: bool = False):
+    nelem = size_bytes // 2  # bfloat16 == 2 bytes
+    if use_cuda:
+        t = torch.randn(nelem, dtype=torch.bfloat16, device="cuda")
+    elif _HAS_CUDA and False:  # opt-in only
+        t = torch.randn(nelem, dtype=torch.bfloat16)
+    else:
+        t = np.random.randn(nelem).astype("float32")[:nelem]
+        size_bytes = t.nbytes  # corrected actual size
+
+    put_times = []
+    get_times = []
+    key = f"bench/{label}"
+    for i in range(iters):
+        t0 = time.perf_counter()
+        cli.put(key, t)
+        put_times.append(time.perf_counter() - t0)
+
+        t0 = time.perf_counter()
+        _ = cli.get(key, device="cuda" if use_cuda else None)
+        get_times.append(time.perf_counter() - t0)
+    cli.delete(key)
+
+    def mb_per_s(times):
+        return size_bytes / statistics.median(times) / 1e6
+
+    return {
+        "size_mb": size_bytes / 1e6,
+        "put_mb_s": mb_per_s(put_times),
+        "get_mb_s": mb_per_s(get_times),
+        "put_median_ms": statistics.median(put_times) * 1e3,
+        "get_median_ms": statistics.median(get_times) * 1e3,
+    }
+
+
+def bench_latency(cli, iters: int):
+    """Small-payload round-trip latency via STAT (no data transfer)."""
+    times = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        cli.stat()
+        times.append(time.perf_counter() - t0)
+    return {
+        "median_us": statistics.median(times) * 1e6,
+        "p99_us": sorted(times)[int(iters * 0.99)] * 1e6,
+        "min_us": min(times) * 1e6,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", required=True, help="bridge server IP (TB-net address)")
+    ap.add_argument("--port", type=int, default=29800)
+    ap.add_argument("--iters", type=int, default=10)
+    ap.add_argument("--cuda", action="store_true", help="test CUDA tensor PUT/GET")
+    args = ap.parse_args()
+
+    cli = TBBridgeClient(args.host, args.port)
+
+    print(f"\nLatency ({args.iters * 4} stat round-trips):")
+    lat = bench_latency(cli, args.iters * 4)
+    print(f"  median={lat['median_us']:.1f}µs  p99={lat['p99_us']:.1f}µs  min={lat['min_us']:.1f}µs")
+
+    print(f"\nBandwidth (numpy float32, {args.iters} iters per size):")
+    print(f"  {'size':>10} {'PUT MB/s':>12} {'GET MB/s':>12} {'PUT ms':>10} {'GET ms':>10}")
+    for size_mb in [1, 16, 64, 256, 1024]:
+        try:
+            r = bench_bandwidth(cli, size_mb * (1 << 20), args.iters, f"np-{size_mb}MB")
+            print(f"  {r['size_mb']:>9.0f}MB {r['put_mb_s']:>12.0f} {r['get_mb_s']:>12.0f} "
+                  f"{r['put_median_ms']:>10.1f} {r['get_median_ms']:>10.1f}")
+        except Exception as e:
+            print(f"  {size_mb}MB -> FAIL: {e}")
+            break
+
+    if args.cuda and _HAS_CUDA:
+        print(f"\nBandwidth (CUDA bfloat16 tensors, {args.iters} iters per size):")
+        print(f"  {'size':>10} {'PUT MB/s':>12} {'GET MB/s':>12} {'PUT ms':>10} {'GET ms':>10}")
+        for size_mb in [16, 64, 256, 1024]:
+            try:
+                r = bench_bandwidth(cli, size_mb * (1 << 20), args.iters, f"cuda-{size_mb}MB",
+                                    use_cuda=True)
+                print(f"  {r['size_mb']:>9.0f}MB {r['put_mb_s']:>12.0f} {r['get_mb_s']:>12.0f} "
+                      f"{r['put_median_ms']:>10.1f} {r['get_median_ms']:>10.1f}")
+            except Exception as e:
+                print(f"  {size_mb}MB -> FAIL: {e}")
+                break
+
+
+if __name__ == "__main__":
+    main()

--- a/bridge/tb_bridge_client.py
+++ b/bridge/tb_bridge_client.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+TB-Bridge client — runs on the training host (Linux + CUDA).
+
+Pushes/pulls PyTorch tensors to a tb_bridge_server. Numpy is the only hard
+dependency; torch is optional (used for zero-copy tensor view if present).
+
+Example:
+    import torch
+    from bridge.tb_bridge_client import TBBridgeClient
+
+    cli = TBBridgeClient(host="10.0.0.2", port=29800)   # mac TB-net IP
+    x = torch.randn(1024, 4096, dtype=torch.bfloat16, device="cuda")
+    cli.put("layer.42.attn", x)                          # offload
+    y = cli.get("layer.42.attn", device="cuda")          # fetch back
+    cli.delete("layer.42.attn")
+
+Designed to be the offload-tier piece of a "Linux trains, Mac holds
+spilled VRAM over TB5" topology. Not RDMA — uses ordinary sockets over
+TB-net IP (which Apple exposes natively over Thunderbolt). Real bandwidth
+on TB5 IP is ~25-40 Gbps, latency 50-200 µs per round-trip.
+"""
+import json
+import socket
+import struct
+from typing import Optional, Sequence
+
+import numpy as np
+
+try:
+    import torch
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+OP_PUT = 1
+OP_GET = 2
+OP_DEL = 3
+OP_LIST = 4
+OP_STAT = 5
+
+_TORCH_TO_NUMPY_DTYPE = {
+    "torch.float32": "float32",
+    "torch.float16": "float16",
+    "torch.bfloat16": "uint16",  # numpy doesn't have bf16; carry bytes as u16
+    "torch.float64": "float64",
+    "torch.int8": "int8",
+    "torch.int16": "int16",
+    "torch.int32": "int32",
+    "torch.int64": "int64",
+    "torch.uint8": "uint8",
+    "torch.bool": "bool",
+}
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    chunks = []
+    remaining = n
+    while remaining:
+        chunk = sock.recv(min(remaining, 1 << 20))
+        if not chunk:
+            raise ConnectionError(f"peer closed with {remaining}/{n} bytes outstanding")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _send_exact(sock: socket.socket, buf):
+    view = memoryview(buf)
+    while view:
+        sent = sock.send(view)
+        view = view[sent:]
+
+
+class TBBridgeClient:
+    """One TCP connection per operation — simpler than pooling, fast enough
+    on TB5 where ~120 µs of TCP overhead is dwarfed by tensor copy time
+    for any tensor over a few MB."""
+
+    def __init__(self, host: str, port: int = 29800, timeout: float = 30.0):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def _connect(self) -> socket.socket:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 16 << 20)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 16 << 20)
+        except OSError:
+            pass
+        sock.connect((self.host, self.port))
+        return sock
+
+    def put(self, key: str, tensor) -> None:
+        """Offload a tensor. Works with torch.Tensor or numpy.ndarray.
+        For torch tensors on GPU, this triggers a host copy (no avoiding it
+        without GPU-aware RDMA)."""
+        if _HAS_TORCH and isinstance(tensor, torch.Tensor):
+            arr_bytes, meta = self._torch_to_bytes(tensor)
+        elif isinstance(tensor, np.ndarray):
+            arr_bytes = tensor.tobytes()
+            meta = {
+                "kind": "numpy",
+                "dtype": str(tensor.dtype),
+                "shape": list(tensor.shape),
+            }
+        else:
+            raise TypeError(f"unsupported tensor type: {type(tensor)}")
+
+        meta_bytes = json.dumps(meta).encode("utf-8")
+        key_bytes = key.encode("utf-8")
+        if len(key_bytes) > 256:
+            raise ValueError("key too long (max 256 bytes UTF-8)")
+
+        sock = self._connect()
+        try:
+            hdr = (
+                bytes([OP_PUT])
+                + struct.pack(">I", len(key_bytes))
+                + key_bytes
+                + struct.pack(">I", len(meta_bytes))
+                + meta_bytes
+                + struct.pack(">Q", len(arr_bytes))
+            )
+            _send_exact(sock, hdr)
+            _send_exact(sock, arr_bytes)
+            status = _recv_exact(sock, 1)[0]
+            if status != 0:
+                raise RuntimeError(f"server returned status {status}")
+        finally:
+            sock.close()
+
+    def get(self, key: str, device: Optional[str] = None):
+        """Fetch a previously-put tensor. Returns the same kind it was
+        stored as (torch on torch, numpy on numpy). For torch, an optional
+        device= moves the result."""
+        key_bytes = key.encode("utf-8")
+        sock = self._connect()
+        try:
+            hdr = bytes([OP_GET]) + struct.pack(">I", len(key_bytes)) + key_bytes
+            _send_exact(sock, hdr)
+            status = _recv_exact(sock, 1)[0]
+            if status != 0:
+                raise KeyError(f"key {key!r} not found on server (status={status})")
+            meta_len = struct.unpack(">I", _recv_exact(sock, 4))[0]
+            meta = json.loads(_recv_exact(sock, meta_len))
+            data_len = struct.unpack(">Q", _recv_exact(sock, 8))[0]
+            data = _recv_exact(sock, data_len)
+        finally:
+            sock.close()
+
+        if meta["kind"] == "torch":
+            return self._bytes_to_torch(data, meta, device=device)
+        elif meta["kind"] == "numpy":
+            arr = np.frombuffer(data, dtype=meta["dtype"]).reshape(meta["shape"])
+            return arr.copy()  # detach from the recv buffer
+        else:
+            raise ValueError(f"unknown tensor kind {meta.get('kind')!r}")
+
+    def delete(self, key: str) -> bool:
+        key_bytes = key.encode("utf-8")
+        sock = self._connect()
+        try:
+            hdr = bytes([OP_DEL]) + struct.pack(">I", len(key_bytes)) + key_bytes
+            _send_exact(sock, hdr)
+            status = _recv_exact(sock, 1)[0]
+            return status == 0
+        finally:
+            sock.close()
+
+    def list(self) -> Sequence[str]:
+        sock = self._connect()
+        try:
+            _send_exact(sock, bytes([OP_LIST]) + struct.pack(">I", 0))
+            status = _recv_exact(sock, 1)[0]
+            if status != 0:
+                raise RuntimeError(f"LIST failed: {status}")
+            n = struct.unpack(">I", _recv_exact(sock, 4))[0]
+            keys = []
+            for _ in range(n):
+                kl = struct.unpack(">I", _recv_exact(sock, 4))[0]
+                keys.append(_recv_exact(sock, kl).decode("utf-8"))
+            return keys
+        finally:
+            sock.close()
+
+    def stat(self):
+        sock = self._connect()
+        try:
+            _send_exact(sock, bytes([OP_STAT]) + struct.pack(">I", 0))
+            status = _recv_exact(sock, 1)[0]
+            if status != 0:
+                raise RuntimeError(f"STAT failed: {status}")
+            total, n = struct.unpack(">QI", _recv_exact(sock, 12))
+            return {"total_bytes": total, "num_keys": n}
+        finally:
+            sock.close()
+
+    # ── torch ↔ bytes helpers ────────────────────────────────────────────
+    def _torch_to_bytes(self, t):
+        # Move to CPU and contiguous before serializing
+        cpu = t.detach().contiguous().cpu()
+        # bf16 carried as raw u16 bytes; numpy doesn't have it
+        if cpu.dtype == torch.bfloat16:
+            buf = cpu.view(torch.uint16).numpy().tobytes()
+        else:
+            buf = cpu.numpy().tobytes()
+        meta = {
+            "kind": "torch",
+            "dtype": str(t.dtype),
+            "shape": list(t.shape),
+        }
+        return buf, meta
+
+    def _bytes_to_torch(self, data: bytes, meta: dict, device: Optional[str] = None):
+        if not _HAS_TORCH:
+            raise RuntimeError("torch not installed but stored tensor is a torch tensor")
+        dtype_str = meta["dtype"]
+        shape = tuple(meta["shape"])
+        if dtype_str == "torch.bfloat16":
+            arr = np.frombuffer(data, dtype="uint16").reshape(shape).copy()
+            t = torch.from_numpy(arr).view(torch.bfloat16)
+        else:
+            np_dtype = _TORCH_TO_NUMPY_DTYPE.get(dtype_str)
+            if np_dtype is None:
+                raise ValueError(f"unsupported dtype {dtype_str}")
+            arr = np.frombuffer(data, dtype=np_dtype).reshape(shape).copy()
+            t = torch.from_numpy(arr)
+            # Restore the original torch dtype (covers cases where torch and
+            # numpy share a bit-level representation but distinct dtype objects)
+            torch_dtype = getattr(torch, dtype_str.removeprefix("torch."))
+            if t.dtype != torch_dtype:
+                t = t.to(torch_dtype)
+        if device:
+            t = t.to(device)
+        return t
+
+
+if __name__ == "__main__":
+    import argparse, sys
+    ap = argparse.ArgumentParser(description="TB-Bridge client CLI")
+    ap.add_argument("--host", required=True)
+    ap.add_argument("--port", type=int, default=29800)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("list")
+    sub.add_parser("stat")
+    d = sub.add_parser("delete"); d.add_argument("key")
+    args = ap.parse_args()
+    cli = TBBridgeClient(args.host, args.port)
+    if args.cmd == "list":
+        for k in cli.list():
+            print(k)
+    elif args.cmd == "stat":
+        s = cli.stat()
+        print(f"{s['total_bytes']/1e9:.2f} GB across {s['num_keys']} keys")
+    elif args.cmd == "delete":
+        ok = cli.delete(args.key)
+        print(f"deleted: {ok}")
+        sys.exit(0 if ok else 1)

--- a/bridge/tb_bridge_server.py
+++ b/bridge/tb_bridge_server.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+TB-Bridge server — runs on the Mac (or any host with extra RAM/VRAM).
+
+Holds tensor blobs in unified memory and serves push/pull over a length-
+prefixed TCP protocol. Intended to run on a Mac across a Thunderbolt 5
+cable from the training host; the TB-net link gives 25-40 Gbps at the
+IP layer without any kernel-driver work.
+
+Why this exists: RDMA-level Mac↔Linux interop in OdinLink-Five still
+requires Apple-protocol XDomain login work that hasn't been verified
+against real hardware. This bridge is the userspace fallback that
+works today — slower than RDMA but immediately usable.
+
+Wire format (per request, all big-endian on the wire):
+    u8   op     (PUT=1, GET=2, DEL=3, LIST=4, STAT=5)
+    u32  key_len
+    u8[] key      (UTF-8 string, ≤ 256 bytes)
+    For PUT:
+        u32  meta_len
+        u8[] meta_json   (dtype, shape, device, etc.)
+        u64  data_len
+        u8[] data        (raw tensor bytes)
+    Response:
+        u8   status (0=OK, nonzero=err)
+        For GET: same payload trailer as PUT
+        For LIST: u32 count + count×(u32 keylen + keystr)
+        For STAT: u64 total_bytes + u32 num_keys
+
+Local storage: a flat dict {key: (meta_bytes, data_bytes)}. Memory is
+the OS-managed mapped bytes — on Apple Silicon this is unified memory
+visible to Metal, so Mac-side training code can mlx-import the buffer
+zero-copy if desired (see bridge/mlx_helpers.py — TODO).
+"""
+import argparse
+import json
+import os
+import socket
+import struct
+import sys
+import threading
+import time
+from typing import Dict, Tuple
+
+OP_PUT = 1
+OP_GET = 2
+OP_DEL = 3
+OP_LIST = 4
+OP_STAT = 5
+
+STATUS_OK = 0
+STATUS_NOT_FOUND = 1
+STATUS_BAD_OP = 2
+STATUS_OOM = 3
+STATUS_PROTOCOL = 4
+
+
+class TensorStore:
+    """In-memory tensor blob store. Thread-safe."""
+
+    def __init__(self, max_bytes: int = 64 * (1 << 30)):
+        self._store: Dict[str, Tuple[bytes, bytes]] = {}
+        self._bytes = 0
+        self._max_bytes = max_bytes
+        self._lock = threading.Lock()
+
+    def put(self, key: str, meta: bytes, data: bytes) -> int:
+        with self._lock:
+            old = self._store.get(key)
+            new_bytes = self._bytes - (len(old[1]) if old else 0) + len(data)
+            if new_bytes > self._max_bytes:
+                return STATUS_OOM
+            self._store[key] = (meta, data)
+            self._bytes = new_bytes
+            return STATUS_OK
+
+    def get(self, key: str):
+        with self._lock:
+            return self._store.get(key)
+
+    def delete(self, key: str) -> bool:
+        with self._lock:
+            old = self._store.pop(key, None)
+            if old is None:
+                return False
+            self._bytes -= len(old[1])
+            return True
+
+    def keys(self):
+        with self._lock:
+            return list(self._store.keys())
+
+    def stat(self):
+        with self._lock:
+            return self._bytes, len(self._store)
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    chunks = []
+    remaining = n
+    while remaining:
+        chunk = sock.recv(min(remaining, 1 << 20))
+        if not chunk:
+            raise ConnectionError(f"peer closed with {remaining}/{n} bytes outstanding")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _send_exact(sock: socket.socket, buf: memoryview):
+    view = memoryview(buf)
+    while view:
+        sent = sock.send(view)
+        view = view[sent:]
+
+
+def handle_client(sock: socket.socket, addr, store: TensorStore, verbose: bool):
+    """One client = one request/response cycle, then close. Simple is fast."""
+    try:
+        op = _recv_exact(sock, 1)[0]
+        key_len = struct.unpack(">I", _recv_exact(sock, 4))[0]
+        if key_len > 256:
+            sock.sendall(bytes([STATUS_PROTOCOL]))
+            return
+        key = _recv_exact(sock, key_len).decode("utf-8")
+
+        if op == OP_PUT:
+            meta_len = struct.unpack(">I", _recv_exact(sock, 4))[0]
+            meta = _recv_exact(sock, meta_len)
+            data_len = struct.unpack(">Q", _recv_exact(sock, 8))[0]
+            data = _recv_exact(sock, data_len)
+            status = store.put(key, meta, data)
+            sock.sendall(bytes([status]))
+            if verbose:
+                print(f"[PUT] {key} meta={meta_len}B data={data_len/1e6:.1f}MB status={status}")
+
+        elif op == OP_GET:
+            entry = store.get(key)
+            if entry is None:
+                sock.sendall(bytes([STATUS_NOT_FOUND]))
+                return
+            meta, data = entry
+            hdr = bytes([STATUS_OK]) + struct.pack(">I", len(meta)) + meta + struct.pack(">Q", len(data))
+            _send_exact(sock, memoryview(hdr))
+            _send_exact(sock, memoryview(data))
+            if verbose:
+                print(f"[GET] {key} -> {len(data)/1e6:.1f}MB")
+
+        elif op == OP_DEL:
+            ok = store.delete(key)
+            sock.sendall(bytes([STATUS_OK if ok else STATUS_NOT_FOUND]))
+            if verbose:
+                print(f"[DEL] {key} ok={ok}")
+
+        elif op == OP_LIST:
+            keys = store.keys()
+            parts = [bytes([STATUS_OK]), struct.pack(">I", len(keys))]
+            for k in keys:
+                kb = k.encode("utf-8")
+                parts.append(struct.pack(">I", len(kb)))
+                parts.append(kb)
+            sock.sendall(b"".join(parts))
+            if verbose:
+                print(f"[LIST] -> {len(keys)} keys")
+
+        elif op == OP_STAT:
+            total, n = store.stat()
+            sock.sendall(bytes([STATUS_OK]) + struct.pack(">QI", total, n))
+            if verbose:
+                print(f"[STAT] {total/1e9:.2f}GB across {n} keys")
+
+        else:
+            sock.sendall(bytes([STATUS_BAD_OP]))
+
+    except (ConnectionError, OSError) as e:
+        if verbose:
+            print(f"[client {addr}] dropped: {e}")
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("--bind", default="0.0.0.0",
+                    help="Bind address. For TB-net, set to the thunderbolt0 IP "
+                         "(or 0.0.0.0 to listen on all interfaces).")
+    ap.add_argument("--port", type=int, default=29800)
+    ap.add_argument("--max-gb", type=float, default=64.0,
+                    help="Max total tensor bytes held in memory (default 64 GB).")
+    ap.add_argument("--verbose", "-v", action="store_true")
+    args = ap.parse_args()
+
+    store = TensorStore(max_bytes=int(args.max_gb * (1 << 30)))
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    # Larger socket buffers help TB5 saturation
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 16 << 20)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 16 << 20)
+    except OSError:
+        pass
+
+    sock.bind((args.bind, args.port))
+    sock.listen(64)
+    print(f"tb_bridge_server listening on {args.bind}:{args.port}  "
+          f"(max {args.max_gb} GB resident)")
+    sys.stdout.flush()
+
+    try:
+        while True:
+            client, addr = sock.accept()
+            client.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            t = threading.Thread(
+                target=handle_client,
+                args=(client, addr, store, args.verbose),
+                daemon=True,
+            )
+            t.start()
+    except KeyboardInterrupt:
+        print("\nshutting down")
+    finally:
+        sock.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/MAC_PROTOCOL_CAPTURE.md
+++ b/docs/MAC_PROTOCOL_CAPTURE.md
@@ -1,0 +1,169 @@
+# Capturing Apple's ThunderboltRDMA Wire Protocol
+
+## Why this exists
+
+OdinLink-Five's `protocol=1` mode advertises Apple's protocol ID
+(`0xFA57` / 64087) and accepts lenient login responses, but the **outbound
+login message** is still serialised in OdinLink's own UUID + opcode +
+field layout. That means a Mac receiving our login probably rejects it,
+because Apple's `AppleThunderboltRDMA.kext` is matching against its own
+expected message format.
+
+To finish Mac↔Linux interop (`protocol=2` mode: actually send Apple-
+compatible login bytes) we need to know:
+
+| Item | Today's status |
+|---|---|
+| Apple's RDMA UUID | Unknown |
+| Login message TYPE opcode | Unknown |
+| Login payload byte layout (transmit_path / proto_version offsets) | Unknown |
+| Login response field layout | Partial (lenient parser already in place) |
+| Hop ID negotiation order | Unknown |
+| NHI ring descriptor format compatibility | Unknown but probably standard NHI |
+
+Every one of these is *recoverable* by running a Mac↔Mac RDMA session
+once and capturing the relevant kernel + IOKit state. This doc shows how.
+
+## What you need
+
+- **Two Macs**, both with **Thunderbolt 5** ports (M4 Mac Mini, M4 Pro/Max
+  MacBook Pro, M3 Ultra Mac Studio, etc. — TB3/TB4 won't work, TN3205
+  is explicit about this).
+- **macOS 26.2 or later** on both.
+- **A TB5-rated cable** (the cheap TB3 passive cables don't carry TB5
+  speeds and won't negotiate RDMA).
+- RDMA enabled on **both** Macs:
+  ```
+  # Boot into macOS Recovery (Apple Silicon: hold power on boot)
+  Terminal → Utilities → Terminal
+  rdma_ctl enable
+  reboot
+  ```
+
+## Run the capture
+
+On *one* of the two Macs (preferably the one that will initiate the
+login — that's whoever connects the cable last):
+
+```bash
+git clone https://github.com/Geramy/OdinLink-Five.git
+cd OdinLink-Five
+chmod +x scripts/mac_rdma_capture.sh
+./scripts/mac_rdma_capture.sh
+```
+
+The script will:
+
+1. Verify macOS version and TB5 hardware
+2. Snapshot `ioreg` Thunderbolt + XDomain + RDMA trees (before)
+3. Start a 40-second `log stream` capture of the Thunderbolt + RDMA
+   subsystems
+4. Wait 20 seconds while you (re-)plug the TB5 cable — the kext will
+   discover the peer and run its XDomain login during this window
+5. Snapshot `ioreg` trees again (after)
+6. Probe `ibv_devinfo` if available
+7. Copy `AppleThunderboltRDMA.kext/Contents/Info.plist` for protocol IDs
+8. Bundle everything into `~/mac_rdma_capture_<timestamp>.tar.gz`
+
+If anything fails in step 5 (peer not visible after connect), the
+script will tell you and the analyser will say so too.
+
+## Analyze the capture
+
+Transfer the tarball to a Linux box (the OdinLink dev machine works fine):
+
+```bash
+scp mymac:~/mac_rdma_capture_*.tar.gz .
+python3 scripts/mac_rdma_analyze.py mac_rdma_capture_<ts>.tar.gz
+```
+
+The analyser will report:
+
+- **Apple's RDMA Protocol ID** and **Protocol Version** (from the kext
+  plist — confirms the well-known `0xFA57` and surfaces the version
+  number, which OdinLink currently hardcodes to 1)
+- **XDomain property dirs** the Mac is advertising (so we know the
+  property-key names to match against — Apple may use `"rdma"` plus
+  some other key we haven't seen)
+- **UUID candidates** from the log stream (the Apple RDMA UUID will
+  appear many times; the most-frequent one is the strongest lead)
+- **Opcode candidates** (any `type=N` / `opcode=N` style strings)
+- **Login lines** — actual `pr_info`-style messages around the login
+  handshake, which is where the message format is described in
+  human-readable form even when the raw bytes aren't logged
+
+It also prints a **next-steps** checklist: what's missing, what's
+ambiguous, what to capture next.
+
+## From capture → driver code
+
+Once you have:
+
+- Apple's RDMA UUID (as a 16-byte UUID literal)
+- Login message TYPE opcode (a small integer)
+- Login payload byte layout (which u32 is `transmit_path`, which is
+  `proto_version`, what reserved fields look like)
+
+…implementing `protocol=2` in `driver/odl_tb5_proto.c` is mechanical:
+
+1. Add a second UUID constant at the top of `odl_tb5_proto.c`:
+   ```c
+   const uuid_t odl_tb5_proto_uuid_apple =
+       UUID_INIT(0xXXXXXXXX, 0xXXXX, 0xXXXX,
+                 0xXX, 0xXX, 0xXX, 0xXX, 0xXX, 0xXX, 0xXX, 0xXX);
+   ```
+2. Add a second login struct (`struct odl_tb5_login_msg_apple`) with the
+   recovered field layout.
+3. In `odl_tb5_proto_send_login()`, branch on `odl_protocol_mode == 2`
+   to fill in the Apple struct, use the Apple UUID, and pass the Apple
+   opcode.
+4. Register the Apple UUID as a second protocol handler in
+   `odl_tb5_proto_register()` so incoming Apple-format login requests
+   are routed to the same handler.
+
+Total surgery: ~150 LoC if the capture nails down all four unknowns.
+
+## What "success" looks like
+
+After implementing `protocol=2` and re-running on Linux:
+
+```bash
+sudo insmod driver/odl_tb5.ko protocol=2
+# On the Mac, plug in the TB5 cable. Then:
+ibv_devinfo
+# should show the Linux peer as a connected RDMA device
+ibv_rc_pingpong -d <device>
+# should complete a ping-pong without error
+```
+
+That's the verbs-level handshake. Sharing GPU VRAM zero-copy still
+requires the dmabuf bridge on the Mac side and is a separate problem
+documented in [`REMOTE_TENSORS.md`](REMOTE_TENSORS.md).
+
+## Why not just sniff PCIe?
+
+Thunderbolt control packets ride on the PCIe upstream link, which would
+normally need a PCIe analyzer (Teledyne LeCroy, Keysight — $$$$).
+However, Apple's kext **logs the high-level handshake** to the `log
+stream` subsystem at the debug level, which is more than enough to
+reconstruct the wire format because Apple's engineers debug the same
+way. PCIe-level capture would only be necessary if Apple suppresses
+the relevant log lines — and so far there's no evidence they do.
+
+If `log stream` turns out to be insufficient, the fallback is a
+DriverKit-based passive shim that interposes between the kext and
+`libthunderboltrdma.dylib` — that's a much bigger project and shouldn't
+be needed for this task.
+
+## Gotchas
+
+- **SIP**: System Integrity Protection blocks some `ioreg` views and
+  may rate-limit `log stream`. If the capture is sparse, disable SIP
+  on a sacrificial Mac (`csrutil disable` from Recovery) and re-run.
+- **First-connect-only**: Apple's kext caches discovery state. If you
+  ran the script once and it captured nothing useful, fully unload the
+  kext (`sudo kmutil unload -p .../AppleThunderboltRDMA.kext`) or
+  reboot before re-running, otherwise the second capture will be
+  noise.
+- **Sleep**: don't let the Mac sleep during capture — the TB controller
+  may renegotiate on wake and you'll get a confusing mix of events.

--- a/docs/REMOTE_TENSORS.md
+++ b/docs/REMOTE_TENSORS.md
@@ -1,0 +1,152 @@
+# Remote Tensors — design sketch for cross-platform VRAM sharing
+
+> **Status**: design doc / architecture sketch. The userspace bridge in
+> [`bridge/`](../bridge/) is the working interim solution. The
+> RDMA-backed implementation depends on
+> [Mac protocol capture work](MAC_PROTOCOL_CAPTURE.md) landing first.
+
+## What problem this solves
+
+You're training on a Linux + NVIDIA GPU with 32 GB of VRAM. You have a
+Mac with 96–192 GB of unified memory sitting on the desk, connected via
+Thunderbolt 5. You want to *treat the Mac's unified memory as an
+extension of the training GPU's VRAM* — push spilled activations,
+attention K/V cache, optimizer state shards across the cable, and pull
+them back when needed.
+
+Three things stand between you and that:
+
+1. **No NCCL on Mac.** NVIDIA's collective library is CUDA-only. AMD's
+   RCCL is ROCm-only. Apple has no equivalent. You can't drop the Mac
+   into a `torch.distributed` process group as a peer.
+2. **No PCI BAR for Apple GPU.** Apple Silicon GPUs use unified memory.
+   They don't expose addressable memory regions for outside peers to
+   DMA into. The "GPUDirect RDMA" trick that lets one NVIDIA GPU read
+   another's VRAM over InfiniBand has no Apple counterpart.
+3. **Different verbs implementations.** Apple ships its own RDMA stack
+   (`libthunderboltrdma.dylib` + `AppleThunderboltRDMA.kext`). OdinLink
+   ships its own. The XDomain handshake formats don't match yet —
+   that's what the [protocol capture work](MAC_PROTOCOL_CAPTURE.md)
+   fixes.
+
+So the right abstraction is **not** "make the Mac a CUDA peer." It's:
+*give the user one Python API that hides whether the remote tensor lives
+on a CUDA device or in Apple unified memory, and let it use the best
+available transport.*
+
+## The API we want
+
+```python
+import torch
+from odinlink.remote import RemoteStore
+
+# Connect to a remote host's memory (TB5 cable to Mac, or another Linux
+# box over RDMA — same API)
+mac = RemoteStore("tb5://mac-tb-ip:29800", capacity="96GB")
+
+# Push a CUDA tensor across the wire. The implementation picks the
+# best transport: GPUDirect-RDMA if peer is CUDA, host-copy+TCP if peer
+# is Apple, etc.
+x = torch.randn(1024, 4096, dtype=torch.bfloat16, device="cuda:0")
+handle = mac.put("kv_cache.layer.42", x)
+
+# Later — pull it back. If we never modified it on the remote side, the
+# implementation may stream lazily.
+y = mac.get("kv_cache.layer.42", device="cuda:0")
+
+# Or: ask the remote side to compute on it
+result = mac.run("softmax", "kv_cache.layer.42", dim=-1)
+
+# Bulk transfers: prefetch + overlap with compute
+with mac.prefetch_window(["layer.39", "layer.40", "layer.41"]):
+    train_step(...)
+```
+
+## Transport layers (selected at runtime)
+
+| Layer | Used when | Bandwidth | Latency | Status |
+|---|---|---|---|---|
+| `cuda-cuda-rdma` (NCCL/GPUDirect) | Both peers are CUDA, IB/RoCE/TB5-RDMA link | 100+ Gbps | ~1 µs | shipped in OdinLink |
+| `tb5-rdma-host-copy` | Linux-CUDA ↔ Mac-Metal, OdinLink driver, host-RAM staging | 50–60 Gbps | ~5 µs | **blocked on Mac protocol** |
+| `tb5-ip` (the [bridge/](../bridge/)) | Anything-to-anything over Thunderbolt-IP | 25–40 Gbps | ~100 µs | shipped — Python-only |
+| `tcp-ethernet` | Fallback over normal LAN | 1–10 Gbps | ~200 µs | trivial |
+
+The transport selection is keyed off **peer device class** and
+**connectivity**:
+
+```
+peer = mac           ──► [tb5-rdma-host-copy] if Apple RDMA + cable up
+                    ──► [tb5-ip]              if Thunderbolt-IP up
+                    ──► [tcp-ethernet]        always
+peer = linux-cuda    ──► [cuda-cuda-rdma]     if OdinLink + cable up
+                    ──► [tcp-ethernet]        otherwise
+```
+
+## Memory layout assumptions
+
+Each `RemoteStore` instance owns a remote address space. Keys are
+strings (≤ 256 B UTF-8). Values are tensors with serialised metadata
+(dtype, shape, layout, device-class, optional KV-cache geometry hints).
+
+The remote side decides where the bytes actually live:
+- On a CUDA peer: by default in pinned host RAM, but the peer can elect
+  to keep hot keys in GPU VRAM via an LRU policy
+- On an Apple peer: in unified memory, which is *simultaneously* CPU-
+  and GPU-addressable on Apple Silicon. The remote daemon can answer
+  "compute X on key K" using Metal without copying
+
+The client gets a `Handle` (lightweight), not the bytes. Bytes only
+move on `get(...)` or `run(...)`. This is essential for offload
+patterns where 95% of operations are "stash this, fetch it back later"
+and only 5% need actual computation.
+
+## What we ship vs. what's deferred
+
+| Component | Now | Later |
+|---|---|---|
+| Userspace bridge (TB5-IP transport) | ✅ working ([`bridge/`](../bridge/)) | connection pooling, mlx zero-copy |
+| Mac↔Linux RDMA verbs handshake | partial (`protocol=1` lenient response) | `protocol=2` (Apple-format outbound) blocked on [capture](MAC_PROTOCOL_CAPTURE.md) |
+| Linux↔Linux CUDA-CUDA over TB5 | ✅ working (NCCL plugin) | — |
+| Unified `RemoteStore` Python API | sketched here | implement once Mac RDMA lands |
+| Tensor-aware compute on remote (`mac.run("softmax", ...)`) | future | requires Metal/CUDA-side compute daemons |
+| Prefetch window / async streaming | future | layer on top once transports settle |
+
+## Why this beats "buy a bigger GPU"
+
+The 96–192 GB on a Mac Studio is real memory you can use *today* for
+offload. At TB5 speeds, the round-trip cost of fetching a 256 MB tensor
+back from the Mac is ~50–100 ms. For training patterns where you spill
+activations between transformer blocks and bring them back during
+backward, that's tolerable if you overlap with compute. It would not
+substitute for local VRAM during the forward path, but it expands the
+*reachable working set* dramatically without buying a new GPU.
+
+The alternative — renting an 80 GB H100 — is faster per step but costs
+$2–4/hr indefinitely. A one-time Mac purchase gets paid back in <1000
+hours of training time. Whether that's a good trade depends on how
+often you train.
+
+## Risks / open questions
+
+1. **Apple GPU is not directly addressable from outside.** Even with
+   perfect Mac↔Linux RDMA, "Mac VRAM" means Apple unified memory
+   reachable from Metal. The Linux GPU never reads it directly; the
+   bytes always staging through Mac host RAM. This is a hard constraint
+   of Apple's architecture, not a software issue.
+2. **TB5 cable quality matters.** Apple's TN3205 requires "active TB5
+   cables for sustained RDMA traffic." Cheap passive cables will
+   negotiate down to TB3 speeds and the RDMA layer will refuse.
+3. **macOS RDMA is new (26.2+).** Apple has not yet committed to API
+   stability. A point release could change the kext's behavior.
+4. **No model-parallel for Mac**: even with this layer working, the
+   Mac can't be a *training* peer — it can only be an offload target.
+   The student model lives entirely on the Linux GPU.
+
+## References
+
+- [`bridge/README.md`](../bridge/README.md) — userspace transport docs
+- [`MAC_PROTOCOL_CAPTURE.md`](MAC_PROTOCOL_CAPTURE.md) — unblocking the RDMA path
+- [`../COMPAT.md`](../COMPAT.md) — Mac↔Linux compatibility matrix and protocol notes
+- Apple TN3205, "Low-latency communication with RDMA over Thunderbolt"
+- d3LLM training write-up (sister project) — motivating use case for
+  bigger effective VRAM during 27B-class fine-tuning

--- a/scripts/mac_rdma_analyze.py
+++ b/scripts/mac_rdma_analyze.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Analyze a tarball produced by `scripts/mac_rdma_capture.sh`.
+
+Extracts the bits of Apple's XDomain protocol that OdinLink-Five needs to
+implement `protocol=2` (Apple-compatible login *send* path, not just the
+lenient response handling already in `protocol=1`).
+
+Specifically attempts to recover:
+- Apple's RDMA service UUID (from the kext Info.plist if present)
+- Protocol ID + Protocol Version (cross-checks the 0xFA57 / 64087 value)
+- XDomain login message TYPE opcode (from logs)
+- Login payload field offsets (transmit_path, proto_version, …)
+- Hop ID exchange order
+
+Most of these are unknowns until a real capture lands. The script emits a
+report indicating which fields it was able to recover and which still need
+human inspection of the raw logs.
+"""
+import argparse
+import json
+import os
+import plistlib
+import re
+import sys
+import tarfile
+from pathlib import Path
+from collections import Counter
+
+
+def open_bundle(path: str) -> Path:
+    """Extract the tarball into a temp dir and return its root."""
+    if path.endswith((".tgz", ".tar.gz")):
+        import tempfile
+        tmp = Path(tempfile.mkdtemp(prefix="mac_rdma_"))
+        with tarfile.open(path) as tf:
+            tf.extractall(tmp)
+        # Find the single subdir
+        children = [c for c in tmp.iterdir() if c.is_dir()]
+        return children[0] if len(children) == 1 else tmp
+    if Path(path).is_dir():
+        return Path(path)
+    raise ValueError(f"unrecognized bundle path: {path}")
+
+
+def parse_kext_plist(root: Path) -> dict:
+    """Return Apple's kext Info.plist as a dict (if captured)."""
+    for name in ["AppleThunderboltRDMA.kext_Info.plist",
+                 "AppleThunderboltRDMA.dext_Info.plist"]:
+        p = root / name
+        if p.exists():
+            with open(p, "rb") as f:
+                return plistlib.load(f)
+    return {}
+
+
+def extract_protocol_ids(plist: dict) -> dict:
+    """Walk the kext plist for IOKitPersonalities → property matches."""
+    found = {}
+    if not plist:
+        return found
+    personalities = plist.get("IOKitPersonalities") or {}
+    for pname, props in personalities.items():
+        match = props.get("IOPropertyMatch")
+        if isinstance(match, dict):
+            pid = match.get("Protocol ID")
+            pver = match.get("Protocol Version")
+            if pid is not None or pver is not None:
+                found[pname] = {"Protocol ID": pid, "Protocol Version": pver,
+                                "Hex Protocol ID": hex(pid) if pid else None}
+        # Some kexts use ProviderClass + a flat key
+        if "Protocol ID" in props:
+            found.setdefault(pname, {})["Protocol ID"] = props["Protocol ID"]
+    return found
+
+
+def parse_xdomain_props(root: Path) -> dict:
+    """Read ioreg_xdomain_after.txt and surface the property dirs."""
+    p = root / "ioreg_xdomain_after.txt"
+    if not p.exists():
+        return {"_note": "ioreg_xdomain_after.txt missing — peer probably did not connect"}
+    text = p.read_text(errors="replace")
+    # Look for "prtcid" = <number> and "ptcvr" / similar
+    fields = {}
+    for key in ("prtcid", "ptcvr", "prtcrev", "prtcstns"):
+        m = re.search(rf'"{key}"\s*=\s*(\d+)', text)
+        if m:
+            fields[key] = int(m.group(1))
+            if key == "prtcid":
+                fields[key + "_hex"] = hex(int(m.group(1)))
+    # Look for protocol *string* directory name
+    keys = re.findall(r'\| \+-o ([A-Za-z0-9_\-]+) <class IOThunderbolt', text)
+    if keys:
+        fields["_property_dirs"] = sorted(set(keys))
+    return fields
+
+
+def parse_log_stream(root: Path) -> dict:
+    """Scan log_stream_filtered.txt for the login/XDomain signal we care about."""
+    p = root / "log_stream_filtered.txt"
+    if not p.exists():
+        # Fall back to full log
+        p = root / "log_stream.txt"
+        if not p.exists():
+            return {"_error": "no log_stream files found"}
+    text = p.read_text(errors="replace")
+
+    findings = {
+        "n_lines": text.count("\n"),
+        "login_lines": [],
+        "uuid_candidates": [],
+        "opcode_candidates": [],
+        "hop_id_lines": [],
+    }
+
+    # Login mentions
+    for line in text.splitlines():
+        ll = line.lower()
+        if "login" in ll and ("rdma" in ll or "xdomain" in ll or "thunderbolt" in ll):
+            findings["login_lines"].append(line[:300])
+        if re.search(r"hop[ -_]?id", ll):
+            findings["hop_id_lines"].append(line[:300])
+        # UUID candidates: 8-4-4-4-12 hex
+        for m in re.finditer(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                              r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b", line):
+            findings["uuid_candidates"].append(m.group(0))
+        # Opcode-like patterns: "type=N" or "msg type N"
+        for m in re.finditer(r"(?:msg.?type|opcode|type)\s*[:=]\s*(0x[0-9a-f]+|\d+)", ll):
+            findings["opcode_candidates"].append(m.group(1))
+
+    # Dedupe + most-common
+    findings["uuid_candidates"] = Counter(findings["uuid_candidates"]).most_common(10)
+    findings["opcode_candidates"] = Counter(findings["opcode_candidates"]).most_common(20)
+    findings["login_lines"] = findings["login_lines"][:30]
+    findings["hop_id_lines"] = findings["hop_id_lines"][:30]
+    return findings
+
+
+def make_report(root: Path) -> dict:
+    plist = parse_kext_plist(root)
+    protocol_ids = extract_protocol_ids(plist)
+    xdomain_props = parse_xdomain_props(root)
+    log_findings = parse_log_stream(root)
+
+    macos_ver = (root / "macos_version.txt")
+    macos_ver_str = macos_ver.read_text().strip() if macos_ver.exists() else "?"
+
+    return {
+        "capture_root": str(root),
+        "macos_version": macos_ver_str,
+        "kext_plist_found": bool(plist),
+        "protocol_ids_from_kext": protocol_ids,
+        "xdomain_properties_after_connect": xdomain_props,
+        "log_findings": log_findings,
+        "next_steps": _next_steps(plist, xdomain_props, log_findings),
+    }
+
+
+def _next_steps(plist, xdomain_props, log_findings) -> list:
+    out = []
+    if not plist:
+        out.append("Apple kext Info.plist was not captured (SIP may have blocked the copy). "
+                   "Try running mac_rdma_capture.sh as root or manually copy "
+                   "/System/Library/Extensions/AppleThunderboltRDMA.kext/Contents/Info.plist")
+    if "_error" in log_findings:
+        out.append("log_stream files missing — capture script may not have run with "
+                   "sufficient privileges. Re-run with `sudo` and ensure `log` allows debug streams.")
+    if not log_findings.get("login_lines"):
+        out.append("No 'login' lines in the log capture. Either the peer didn't connect "
+                   "during the 20-second window (re-plug the cable during the capture) "
+                   "or Apple's log subsystem suppresses RDMA login messages by default. "
+                   "Try widening the predicate in mac_rdma_capture.sh.")
+    if not xdomain_props or xdomain_props.get("_note"):
+        out.append("No XDomain peer properties recorded post-connect. Verify "
+                   "`rdma_ctl enable` was run on both Macs (in Recovery) and that "
+                   "`ibv_devinfo` shows the device on at least one side.")
+    if log_findings.get("uuid_candidates"):
+        out.append("UUID candidates found — cross-reference these against the kext "
+                   "personalities to identify Apple's RDMA proto UUID. "
+                   f"Top candidate: {log_findings['uuid_candidates'][0]}")
+    if not out:
+        out.append("Capture looks complete. Hand-inspect log_stream_filtered.txt for "
+                   "the exact login message bytes; encode those into a new "
+                   "odl_tb5_login_msg_apple struct in driver/odl_tb5_proto.c.")
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("bundle", help="path to .tar.gz or extracted directory")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of human report")
+    args = ap.parse_args()
+
+    root = open_bundle(args.bundle)
+    report = make_report(root)
+
+    if args.json:
+        json.dump(report, sys.stdout, indent=2, default=str)
+        print()
+        return
+
+    print(f"=== mac_rdma_analyze — {report['capture_root']} ===")
+    print(f"macOS: {report['macos_version']}")
+    print()
+    print("[1] Apple kext personalities (Protocol IDs):")
+    if report["protocol_ids_from_kext"]:
+        for pname, props in report["protocol_ids_from_kext"].items():
+            print(f"  {pname}:")
+            for k, v in props.items():
+                print(f"    {k}: {v}")
+    else:
+        print("  none (kext plist not captured)")
+    print()
+    print("[2] XDomain peer properties (post-connect):")
+    if isinstance(report["xdomain_properties_after_connect"], dict):
+        for k, v in report["xdomain_properties_after_connect"].items():
+            print(f"  {k}: {v}")
+    print()
+    print("[3] Log findings:")
+    lf = report["log_findings"]
+    if "_error" in lf:
+        print(f"  ERROR: {lf['_error']}")
+    else:
+        print(f"  total lines parsed: {lf.get('n_lines', 0)}")
+        print(f"  login lines: {len(lf.get('login_lines', []))}")
+        print(f"  hop-id lines: {len(lf.get('hop_id_lines', []))}")
+        if lf.get("uuid_candidates"):
+            print("  top UUID candidates:")
+            for u, n in lf["uuid_candidates"][:5]:
+                print(f"    {u}  ({n}×)")
+        if lf.get("opcode_candidates"):
+            print("  top opcode candidates:")
+            for o, n in lf["opcode_candidates"][:5]:
+                print(f"    {o}  ({n}×)")
+        if lf.get("login_lines"):
+            print("  sample login log lines:")
+            for ln in lf["login_lines"][:5]:
+                print(f"    {ln}")
+    print()
+    print("[4] Next steps:")
+    for s in report["next_steps"]:
+        print(f"  • {s}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mac_rdma_capture.sh
+++ b/scripts/mac_rdma_capture.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# mac_rdma_capture.sh — collect all the data needed to reverse-engineer
+# Apple's ThunderboltRDMA XDomain wire protocol.
+#
+# Run this on a Mac with TB5 hardware connected to ANOTHER Mac (also TB5)
+# with RDMA enabled. Apple's stack discovers the peer via XDomain; we
+# snapshot the discovery state and stream the kernel/RDMA logs while
+# the connect happens.
+#
+# Prerequisites:
+#   - macOS 26.2+ on Apple Silicon (Apple ThunderboltRDMA shipped here)
+#   - Two Macs, both with TB5 ports
+#   - TB5 cable (TB3/TB4 cables won't work — TN3205 confirms HW requirement)
+#   - RDMA enabled on both: boot into Recovery → Terminal → `rdma_ctl enable`
+#   - Reboot back to macOS
+#   - This script run on EITHER Mac (better to run on the side that initiates
+#     the login — usually whoever connects last)
+#
+# Output: a timestamped tarball with everything OdinLink-Five needs to
+# implement `protocol=2` (Apple-compatible login send path).
+
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "ERROR: this script must run on macOS (got $(uname))"
+    exit 1
+fi
+
+OUTDIR="${1:-$HOME/mac_rdma_capture_$(date +%Y%m%d_%H%M%S)}"
+mkdir -p "$OUTDIR"
+echo "==> capture output: $OUTDIR"
+
+# ── Prereqs check ──────────────────────────────────────────────────────────
+echo
+echo "==> [1/8] Checking prerequisites"
+macos_ver=$(sw_vers -productVersion)
+echo "  macOS: $macos_ver"
+echo "$macos_ver" > "$OUTDIR/macos_version.txt"
+
+arch=$(uname -m)
+echo "  arch:  $arch"
+[[ "$arch" != "arm64" ]] && echo "  WARNING: Apple Silicon required for RDMA"
+
+# Check kext
+if kextstat 2>/dev/null | grep -qi ThunderboltRDMA; then
+    echo "  ThunderboltRDMA.kext: loaded ✓"
+    kextstat 2>/dev/null | grep -i Thunderbolt > "$OUTDIR/kextstat_thunderbolt.txt"
+else
+    echo "  ThunderboltRDMA.kext: NOT loaded — kext loads automatically when a TB5 RDMA peer is detected."
+fi
+
+# ── 2. Hardware inventory ─────────────────────────────────────────────────
+echo
+echo "==> [2/8] Snapshotting Thunderbolt hardware"
+system_profiler SPThunderboltDataType > "$OUTDIR/thunderbolt_hw.txt" 2>&1
+echo "  -> thunderbolt_hw.txt ($(wc -l < "$OUTDIR/thunderbolt_hw.txt") lines)"
+
+# Check we have actual TB5
+if grep -qi "thunderbolt 5\|usb4.*v2\|80 *gb" "$OUTDIR/thunderbolt_hw.txt"; then
+    echo "  TB5 link: detected ✓"
+else
+    echo "  TB5 link: NOT detected — capture will fail without TB5"
+    echo "  (RDMA only works on Thunderbolt 5 hardware per TN3205)"
+fi
+
+# ── 3. IOKit Thunderbolt XDomain tree (BEFORE peer connect) ───────────────
+echo
+echo "==> [3/8] IOKit XDomain tree (BEFORE peer connect)"
+ioreg -lw0 -c IOThunderboltSwitch > "$OUTDIR/ioreg_thunderbolt_before.txt" 2>&1
+ioreg -r -c IOThunderboltXDomainService > "$OUTDIR/ioreg_xdomain_before.txt" 2>&1
+ioreg -r -c AppleThunderboltRDMA > "$OUTDIR/ioreg_rdma_before.txt" 2>&1
+echo "  -> ioreg_*_before.txt"
+
+# ── 4. Start log capture in background ────────────────────────────────────
+echo
+echo "==> [4/8] Starting log capture (40 seconds of Thunderbolt subsystem)"
+# Predicate covers anything mentioning Thunderbolt or RDMA. Use --debug
+# to get kernel-level messages too.
+log stream --debug \
+    --predicate 'subsystem CONTAINS "thunderbolt" OR subsystem CONTAINS "rdma" OR senderImagePath CONTAINS "Thunderbolt" OR senderImagePath CONTAINS "RDMA"' \
+    > "$OUTDIR/log_stream.txt" 2>&1 &
+LOG_PID=$!
+echo "  log stream PID: $LOG_PID"
+
+cleanup() {
+    if kill -0 "$LOG_PID" 2>/dev/null; then
+        kill "$LOG_PID" 2>/dev/null || true
+        wait "$LOG_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# Brief wait for log stream to spin up
+sleep 2
+
+# ── 5. Trigger RDMA connect ───────────────────────────────────────────────
+echo
+echo "==> [5/8] Triggering RDMA connection"
+echo "  Please now PHYSICALLY connect the TB5 cable to the peer Mac"
+echo "  (or unplug & replug if already connected)"
+echo "  Waiting 20 seconds for handshake..."
+echo
+
+sleep 20
+
+# ── 6. IOKit snapshot (AFTER peer connect) ────────────────────────────────
+echo "==> [6/8] IOKit XDomain tree (AFTER peer connect)"
+ioreg -lw0 -c IOThunderboltSwitch > "$OUTDIR/ioreg_thunderbolt_after.txt" 2>&1
+ioreg -r -c IOThunderboltXDomainService > "$OUTDIR/ioreg_xdomain_after.txt" 2>&1
+ioreg -r -c AppleThunderboltRDMA > "$OUTDIR/ioreg_rdma_after.txt" 2>&1
+echo "  -> ioreg_*_after.txt"
+
+# Diff the before/after to highlight what changed during connect
+diff -u "$OUTDIR/ioreg_xdomain_before.txt" "$OUTDIR/ioreg_xdomain_after.txt" \
+    > "$OUTDIR/ioreg_xdomain_diff.txt" 2>&1 || true
+diff -u "$OUTDIR/ioreg_rdma_before.txt" "$OUTDIR/ioreg_rdma_after.txt" \
+    > "$OUTDIR/ioreg_rdma_diff.txt" 2>&1 || true
+
+# ── 7. Probe with ibv_devinfo + ibv_rc_pingpong if available ──────────────
+echo
+echo "==> [7/8] Probe RDMA verbs API"
+if command -v ibv_devinfo >/dev/null 2>&1; then
+    ibv_devinfo > "$OUTDIR/ibv_devinfo.txt" 2>&1 || true
+    ibv_devinfo -v >> "$OUTDIR/ibv_devinfo.txt" 2>&1 || true
+    echo "  -> ibv_devinfo.txt"
+else
+    echo "  ibv_devinfo not installed. Apple's libthunderboltrdma.dylib"
+    echo "  ships the verbs binaries — they're under"
+    echo "  /System/Library/PrivateFrameworks/ThunderboltRDMA.framework/Versions/A/Helpers/"
+    if [[ -d /System/Library/PrivateFrameworks/ThunderboltRDMA.framework ]]; then
+        ls -la /System/Library/PrivateFrameworks/ThunderboltRDMA.framework/ \
+            > "$OUTDIR/ls_apple_rdma_framework.txt" 2>&1 || true
+    fi
+fi
+
+# Drop the kext Info.plist if accessible (advertises protocol IDs we need)
+APPLE_KEXT="/System/Library/Extensions/AppleThunderboltRDMA.kext"
+APPLE_KEXT_DT="/System/Library/DriverExtensions/AppleThunderboltRDMA.dext"
+for kext in "$APPLE_KEXT" "$APPLE_KEXT_DT"; do
+    if [[ -d "$kext" ]]; then
+        cp -R "$kext/Contents/Info.plist" "$OUTDIR/$(basename "$kext")_Info.plist" 2>/dev/null || true
+    fi
+done
+
+# ── 8. Stop log capture, package the bundle ───────────────────────────────
+echo
+echo "==> [8/8] Stopping log capture"
+sleep 2  # let log stream catch up
+kill "$LOG_PID" 2>/dev/null || true
+wait "$LOG_PID" 2>/dev/null || true
+trap - EXIT
+
+# Filter log_stream for the high-signal lines so the analyst doesn't drown
+grep -iE "login|xdomain|protocol|hop|ring|rdma|connect|handshake|uuid|prtcid" \
+    "$OUTDIR/log_stream.txt" > "$OUTDIR/log_stream_filtered.txt" 2>/dev/null || true
+
+# Summary
+echo
+echo "==> Summary"
+{
+    echo "macOS: $macos_ver  arch: $arch  captured: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo
+    echo "Files (size):"
+    cd "$OUTDIR" && du -h *
+} > "$OUTDIR/SUMMARY.txt"
+cat "$OUTDIR/SUMMARY.txt"
+
+# Bundle for transport
+BUNDLE="$(dirname "$OUTDIR")/$(basename "$OUTDIR").tar.gz"
+tar czf "$BUNDLE" -C "$(dirname "$OUTDIR")" "$(basename "$OUTDIR")"
+echo
+echo "==> Bundle: $BUNDLE"
+echo "==> Transfer this to the OdinLink-Five Linux machine and run:"
+echo "      python3 scripts/mac_rdma_analyze.py $BUNDLE"
+echo
+echo "Done."


### PR DESCRIPTION
## Summary

Three pieces that move Mac↔Linux interop forward without shipping untested kernel code:

- **`bridge/`** — userspace tensor offload over Thunderbolt-IP. Python client/server, ~25–40 Gbps over TB5, works today with no kernel changes. Lets a Linux+CUDA training host treat a Mac's unified memory as an offload tier.
- **`scripts/mac_rdma_capture.sh` + `mac_rdma_analyze.py`** — Mac↔Mac RDMA wire-protocol capture workflow. Run on macOS during a TB5 RDMA peer connect, parsed offline on Linux. Recovers the unknowns that block writing `protocol=2` mode in `driver/odl_tb5_proto.c` (Apple UUID, login opcode, payload layout, hop-ID negotiation).
- **`docs/MAC_PROTOCOL_CAPTURE.md` + `docs/REMOTE_TENSORS.md`** — the procedure + the eventual unified `RemoteStore` Python API sketch.

No driver changes. Sending Apple-format login bytes against a guessed wire format is a recipe for hard-to-debug kernel issues — the capture work is the prerequisite.

## Test plan

- [ ] `python3 bridge/tb_bridge_server.py --bind 127.0.0.1` + `python3 bridge/benchmark.py --host 127.0.0.1` round-trips against itself
- [ ] On a Mac with TB5 hardware + macOS 26.2+ + `rdma_ctl enable`: `scripts/mac_rdma_capture.sh` produces a tarball
- [ ] `python3 scripts/mac_rdma_analyze.py <tarball>` parses the capture and reports recovered fields
- [ ] `bridge/` between an actual Mac and Linux box at ≥1 GB/s on TB5 IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)
