### PR TITLE
Strix Halo (gfx1151) over Thunderbolt: fix RX-queue overflow hang + ncclNet_v7 ABI, add repro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ NOTES
 TODO
 *.note
 *.scratch
+odl_stress

--- a/driver/odl_tb5_ring_dma.c
+++ b/driver/odl_tb5_ring_dma.c
@@ -1344,14 +1344,17 @@ struct odl_tb5_stream *odl_tb5_stream_create(struct odl_tb5_device *dev,
 	INIT_LIST_HEAD(&stream->rx_queue);
 	spin_lock_init(&stream->rx_lock);
 	stream->rx_queue_len = 0;
-	stream->rx_queue_max = 256;
+	stream->rx_queue_max = 65536;   /* was 256: a single ~1MB msg = ~264 frames;
+					 * under load the sender runs >256 frames ahead
+					 * and the old cap silently DROPPED frames ->
+					 * plugin framing desync -> vLLM hang. */
 	atomic_set(&stream->rx_complete, 0);
 	init_waitqueue_head(&stream->rx_waitq);
 
 	kref_init(&stream->refcount);
 
 	mutex_lock(&dev->stream_lock);
-	hash_add(dev->streams, &stream->node, stream->id);
+	hash_add_rcu(dev->streams, &stream->node, stream->id);
 	mutex_unlock(&dev->stream_lock);
 
 	if (owner) {
@@ -1427,9 +1430,12 @@ struct odl_tb5_stream *odl_tb5_stream_lookup(struct odl_tb5_device *dev,
 	struct odl_tb5_stream *stream;
 
 	rcu_read_lock();
-	hash_for_each_possible(dev->streams, stream, node, stream_id) {
+	hash_for_each_possible_rcu(dev->streams, stream, node, stream_id) {
 		if (stream->id == stream_id) {
-			kref_get(&stream->refcount);
+			/* Stream may be concurrently freed (hash_del_rcu in
+			 * stream_destroy); only take a ref if still alive. */
+			if (!kref_get_unless_zero(&stream->refcount))
+				break;
 			rcu_read_unlock();
 			return stream;
 		}

--- a/driver/odl_tb5_service.c
+++ b/driver/odl_tb5_service.c
@@ -107,8 +107,16 @@ static int odl_tb5_probe(struct tb_service *svc,
 	/* Adaptive TX mode defaults */
 	dev->tx_adaptive.mode = ODL_TB5_TX_LATENCY;
 	dev->tx_adaptive.consecutive_low = 0;
-	dev->tx_adaptive.high_watermark = odl_ring_size * 3 / 4;
-	dev->tx_adaptive.low_watermark  = odl_ring_size / 4;
+	/* Watermarks gate the shared frame pool (ODL_TB5_FRAME_POOL_SIZE
+	 * slots), NOT the NHI ring depth.  With large odl_ring_size the raw
+	 * ring*3/4 exceeds the pool, so the adaptive logic can never trip and
+	 * TX flow control is miscalibrated.  Clamp to the usable pool. */
+	dev->tx_adaptive.high_watermark =
+		min_t(unsigned int, odl_ring_size * 3 / 4,
+		      ODL_TB5_FRAME_POOL_SIZE - ODL_TB5_TX_POOL_RESERVE);
+	dev->tx_adaptive.low_watermark  =
+		min_t(unsigned int, odl_ring_size / 4,
+		      (ODL_TB5_FRAME_POOL_SIZE - ODL_TB5_TX_POOL_RESERVE) / 2);
 
 	ret = odl_tb5_chardev_create(dev);
 	if (ret) {

--- a/odl_stress.c
+++ b/odl_stress.c
@@ -1,0 +1,166 @@
+/* odl_stress.c — reproduce the RCCL plugin's framing under concurrency, WITHOUT
+ * RCCL/vLLM, to isolate whether the OdinLink stream layer loses/desyncs messages.
+ *
+ * Faithfully mirrors plugin do_transfer(): each message = [4-byte size header]
+ * + payload in <=ODL_CHUNK single-frame sends, over N concurrent streams that
+ * share ONE handle (like the plugin's g_handle). Payload carries a 4-byte
+ * sequence number so the receiver detects lost/reordered/short/empty messages.
+ *
+ *   server:  ./odl_stress server <N> <msg_bytes> <iters>
+ *   client:  ./odl_stress client <N> <msg_bytes> <iters>
+ * Server opens recv streams with FIXED ids 1..N; client sends to dst=1..N.
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <odl_tb5/odl_tb5.h>
+
+#define ODL_CHUNK 4000
+
+static odl_tb5_t H;
+static int N, ITERS;
+static size_t MSG;
+
+struct sctx { int idx; uint8_t sid; uint8_t dst; };
+
+/* Mixed message sizes like RCCL: tiny control-ish + medium + large, so the
+ * kernel rx demux sees small frames interleaved with big chunked transfers. */
+static size_t size_for(int it)
+{
+	switch (it & 3) {
+	case 0:  return MSG;      /* large  (1 MB) */
+	case 1:  return 350208;   /* medium */
+	case 2:  return 128;      /* tiny   */
+	default: return 8192;     /* small  */
+	}
+}
+
+static void fill(uint8_t *b, size_t n, uint32_t seq)
+{
+	memcpy(b, &seq, 4);
+	for (size_t j = 4; j < n; j++) b[j] = (uint8_t)((seq + j) & 0xff);
+}
+
+/* ---- client: one sender thread per stream (plugin send framing) ---- */
+static void *sender(void *a)
+{
+	struct sctx *c = a;
+	uint8_t *buf = malloc(MSG);
+	for (int it = 0; it < ITERS; it++) {
+		size_t sz = size_for(it);
+		fill(buf, sz, (uint32_t)it);
+		uint32_t hdr = (uint32_t)sz;
+		int ret = odl_tb5_stream_send(H, c->sid, c->dst, &hdr, sizeof(hdr));
+		size_t off = 0;
+		while (ret >= 0 && off < sz) {
+			size_t n = sz - off; if (n > ODL_CHUNK) n = ODL_CHUNK;
+			ret = odl_tb5_stream_send(H, c->sid, c->dst, buf + off, (uint32_t)n);
+			off += n;
+		}
+		if (ret < 0) { printf("[s%d] SEND FAIL it=%d ret=%d\n", c->idx, it, ret); break; }
+	}
+	printf("[s%d] sender done (%d msgs to dst=%u)\n", c->idx, ITERS, c->dst);
+	free(buf); return NULL;
+}
+
+/* ---- server: one receiver thread per stream (plugin recv framing) ---- */
+static void *receiver(void *a)
+{
+	struct sctx *c = a;
+	uint8_t *buf = malloc(MSG);
+	long ok = 0, zero = 0, shorthdr = 0, shortpay = 0, seqbad = 0, bytebad = 0;
+	for (int expect = 0; expect < ITERS; expect++) {
+		size_t expsz = size_for(expect);
+		uint32_t total = 0, actual = 0; uint8_t src = 0;
+		int ret = odl_tb5_stream_recv(H, c->sid, &total, sizeof(total), &src, &actual);
+		if (ret < 0) { printf("[r%d] RECV hdr FAIL expect=%d ret=%d\n", c->idx, expect, ret); break; }
+		if (actual != sizeof(total)) { shorthdr++; printf("[r%d] SHORT HDR expect=%d actual=%u\n", c->idx, expect, actual); continue; }
+		if (total != expsz) { zero += (total == 0); seqbad += (total != 0); printf("[r%d] HDR MISMATCH expect=%d want_sz=%zu got_sz=%u (DESYNC)\n", c->idx, expect, expsz, total); }
+		if (total > MSG) total = MSG;
+		size_t off = 0; int bad = 0;
+		while (off < total) {
+			size_t n = total - off; if (n > ODL_CHUNK) n = ODL_CHUNK;
+			ret = odl_tb5_stream_recv(H, c->sid, buf + off, (uint32_t)n, &src, &actual);
+			if (ret < 0) { printf("[r%d] RECV chunk FAIL expect=%d ret=%d\n", c->idx, expect, ret); bad = 1; break; }
+			off += actual;
+			if (actual == 0) break;
+		}
+		if (off != expsz) { shortpay++; if (shortpay<=3) printf("[r%d] SHORT PAYLOAD expect=%d got=%zu/%zu\n", c->idx, expect, off, expsz); continue; }
+		uint32_t seq; memcpy(&seq, buf, 4);
+		if ((int)seq != expect) { seqbad++; if (seqbad<=3) printf("[r%d] SEQ MISMATCH want=%d got=%u (desync!)\n", c->idx, expect, seq); }
+		else if (buf[expsz/2] != (uint8_t)((seq + expsz/2) & 0xff)) { bytebad++; }
+		else ok++;
+		(void)bad;
+		if ((expect % 50) == 0) printf("[r%d] progress %d/%d ok=%ld\n", c->idx, expect, ITERS, ok);
+	}
+	printf("[r%d] SUMMARY sid=%u ok=%ld zero=%ld shorthdr=%ld shortpay=%ld seqbad=%ld bytebad=%ld\n",
+	       c->idx, c->sid, ok, zero, shorthdr, shortpay, seqbad, bytebad);
+	free(buf); return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	if (argc < 5) { fprintf(stderr, "usage: %s server|client N msg iters\n", argv[0]); return 2; }
+	int server = !strcmp(argv[1], "server");
+	N = atoi(argv[2]); MSG = strtoul(argv[3], NULL, 10); ITERS = atoi(argv[4]);
+	setvbuf(stdout, NULL, _IOLBF, 0);
+
+	if (odl_tb5_open(&H, 0) < 0) { perror("open"); return 1; }
+	if (odl_tb5_wait_peer(H, 15000) < 0) { fprintf(stderr, "wait_peer failed\n"); return 1; }
+	printf("%s: link up, N=%d msg=%zu iters=%d chunk=%d\n", argv[1], N, MSG, ITERS, ODL_CHUNK);
+
+	int duplex = !strcmp(argv[1], "duplex");
+	if (duplex) {
+		/* Both nodes send AND receive on N streams each — mirrors vLLM,
+		 * where every rank drives TX and RX on the shared handle at once
+		 * (TX/RX contend for the same frame pool). Recv ids fixed 1..N;
+		 * senders target the peer's ids 1..N. */
+		struct sctx *rc = calloc(N, sizeof(*rc)), *sc = calloc(N, sizeof(*sc));
+		pthread_t *rt = calloc(N, sizeof(*rt)), *st = calloc(N, sizeof(*st));
+		for (int i = 0; i < N; i++) {
+			uint8_t rsid, ssid;
+			if (odl_tb5_stream_open(H, (uint8_t)(i + 1), &rsid) < 0) { fprintf(stderr, "recv stream_open %d failed\n", i+1); return 1; }
+			if (odl_tb5_stream_open(H, 0, &ssid) < 0) { fprintf(stderr, "send stream_open failed\n"); return 1; }
+			rc[i].idx = i; rc[i].sid = rsid;
+			sc[i].idx = i; sc[i].sid = ssid; sc[i].dst = (uint8_t)(i + 1);
+		}
+		printf("duplex: %d recv + %d send streams open\n", N, N);
+		sleep(3);  /* both post recv streams before anyone sends */
+		for (int i = 0; i < N; i++) pthread_create(&rt[i], NULL, receiver, &rc[i]);
+		for (int i = 0; i < N; i++) pthread_create(&st[i], NULL, sender,   &sc[i]);
+		for (int i = 0; i < N; i++) pthread_join(st[i], NULL);
+		for (int i = 0; i < N; i++) pthread_join(rt[i], NULL);
+		printf("duplex: ALL THREADS JOINED\n");
+		odl_tb5_close(H);
+		return 0;
+	}
+
+	struct sctx *c = calloc(N, sizeof(*c));
+	pthread_t *t = calloc(N, sizeof(*t));
+	for (int i = 0; i < N; i++) {
+		c[i].idx = i; c[i].dst = (uint8_t)(i + 1);
+		uint8_t sid;
+		if (server) {
+			/* fixed recv id i+1 so client can target it */
+			if (odl_tb5_stream_open(H, (uint8_t)(i + 1), &sid) < 0) { fprintf(stderr, "srv stream_open %d failed\n", i+1); return 1; }
+		} else {
+			if (odl_tb5_stream_open(H, 0, &sid) < 0) { fprintf(stderr, "cli stream_open failed\n"); return 1; }
+		}
+		c[i].sid = sid;
+	}
+	printf("%s: %d streams open\n", argv[1], N);
+	if (!server) sleep(2);  /* let server post its recv streams first */
+
+	for (int i = 0; i < N; i++)
+		pthread_create(&t[i], NULL, server ? receiver : sender, &c[i]);
+	for (int i = 0; i < N; i++)
+		pthread_join(t[i], NULL);
+
+	printf("%s: ALL THREADS JOINED\n", argv[1]);
+	odl_tb5_close(H);
+	return 0;
+}

--- a/rccl/src/odl_tb5_plugin.c
+++ b/rccl/src/odl_tb5_plugin.c
@@ -1,12 +1,21 @@
 /*
  * OdinLink Thunderbolt 5 - RCCL Net v7 Plugin
  *
- * Implements the RCCL network plugin interface using the OdinLink
- * TB5 driver. Uses the external buffer path (DMA-buf) - RCCL provides
- * its own GPU buffers which are passed through directly to the driver.
+ * Implements the RCCL/NCCL network plugin interface (ncclNet_v7) using the
+ * OdinLink TB5 driver's stream API.
  *
- * Exposes shared-memory stats at /run/odl_tb5/rccl_stats so the
- * daemon can report TX/RX counters, op counts, and uptime.
+ * Design:
+ *  - Advertises NCCL_PTR_HOST only, so RCCL stages GPU<->host itself and
+ *    hands us host pointers (no HIP dependency here).
+ *  - One shared, ref-counted device handle per process; each NCCL
+ *    connection is a stream multiplexed over the single TB point-to-point
+ *    link (rather than opening the device N times).
+ *  - odl_tb5_stream_send/recv are blocking, so isend/irecv run the actual
+ *    transfer on a detached background thread and return an immediately-
+ *    pollable request; test() reports the done flag.  This preserves the
+ *    non-blocking semantics RCCL's proxy progress loop requires.
+ *
+ * Exposes shared-memory stats at /run/odl_tb5/rccl_stats.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,6 +26,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <time.h>
+#include <pthread.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -27,6 +37,33 @@
 
 #define ODL_TB5_MAX_RCCL_DEVICES 16
 
+/* ── Opt-in debug tracing (ODL_DEBUG=1 request-level, =2 also per-chunk) ────
+ * Writes one file per process: /tmp/odl_plugin.<pid>.log (line-buffered).
+ * Purpose: see whether RCCL actually posts a collective to this net plugin,
+ * and if so which isend/irecv on which stream blocks. */
+static int   odl_dbg;
+static FILE *odl_dbg_fp;
+static void odl_dbg_init(void)
+{
+	const char *e = getenv("ODL_DEBUG");
+	odl_dbg = e ? atoi(e) : 0;
+	if (!odl_dbg)
+		return;
+	char path[128];
+	snprintf(path, sizeof(path), "/tmp/odl_plugin.%d.log", (int)getpid());
+	odl_dbg_fp = fopen(path, "w");
+	if (!odl_dbg_fp)
+		odl_dbg_fp = stderr;
+	setvbuf(odl_dbg_fp, NULL, _IOLBF, 0);
+}
+#define DBG(lvl, fmt, ...) do { \
+	if (odl_dbg >= (lvl) && odl_dbg_fp) { \
+		struct timespec _ts; clock_gettime(CLOCK_MONOTONIC, &_ts); \
+		fprintf(odl_dbg_fp, "[%ld.%03ld t%04lx] " fmt "\n", \
+			(long)_ts.tv_sec, _ts.tv_nsec / 1000000, \
+			(unsigned long)pthread_self() & 0xffff, ##__VA_ARGS__); \
+	} } while (0)
+
 static rcclDebugLogger_t odl_logger;
 static char hw_ids[ODL_TB5_MAX_RCCL_DEVICES][64];
 static int num_devices;
@@ -34,23 +71,62 @@ static int num_devices;
 static struct odl_rccl_stats *stats_map;
 static int stats_fd = -1;
 
-/* Communication handle - shared by send and recv */
+/* ── Shared device handle (one TB link, many streams) ──────────────── */
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static odl_tb5_t       g_handle;            /* opened lazily */
+static int             g_handle_refs;
+static uint8_t         g_next_cid = 1;      /* connection/stream id alloc */
+
+struct odl_tb5_request;
+
+/* Per-connection communicator.  A single worker thread drains a FIFO queue
+ * of requests so transfers on this stream happen strictly in the order RCCL
+ * posted them (RCCL matches sends/recvs in order per connection) and never
+ * concurrently. */
 struct odl_tb5_comm {
-	odl_tb5_t handle;
-	int refcount;
+	odl_tb5_t handle;    /* shared g_handle */
+	uint8_t   stream_id; /* local stream to send-from / recv-on */
+	uint8_t   dst_id;    /* remote stream to deliver to (send side) */
+	int       is_send;
+
+	pthread_t       worker;
+	pthread_mutex_t q_lock;
+	pthread_cond_t  q_cond;
+	struct odl_tb5_request *q_head, *q_tail;
+	int             stop;
+	int             worker_started;
 };
 
-/* Async request tracking */
+/* Async request: queued to its comm's worker thread. */
 struct odl_tb5_request {
-	bool done;
-	int  size;
+	struct odl_tb5_comm *comm;
+	void   *data;
+	int     size;         /* requested size */
+	int     done_size;    /* actual transferred size */
+	int     is_send;
+	volatile int done;    /* set by worker thread */
+	volatile int failed;
+	struct odl_tb5_request *next;   /* queue linkage */
 };
 
-/* Listen handle */
+/* Listen handle: owns a pre-opened recv stream whose (auto-assigned) id is
+ * advertised to the connecting peer so it can target it as dst. */
 struct odl_tb5_listen_handle {
-	int  dev_id;
-	char hw_id[64];
+	int       dev_id;
+	odl_tb5_t handle;     /* shared handle ref held until accept/closeListen */
+	uint8_t   stream_id;  /* auto-assigned recv stream */
+	int       accepted;   /* ref transferred to recvComm */
+	char      hw_id[64];
 };
+
+/* Memory registration handle (host staging: nothing to pin). */
+struct odl_tb5_mr {
+	void  *data;
+	size_t size;
+};
+
+static int comm_start_worker(struct odl_tb5_comm *comm);
+static void comm_stop_worker(struct odl_tb5_comm *comm);
 
 static uint64_t clock_mono_ns(void)
 {
@@ -62,17 +138,14 @@ static uint64_t clock_mono_ns(void)
 static void stats_init(void)
 {
 	mkdir(ODL_RCCL_STATS_DIR, 0755);
-
 	stats_fd = open(ODL_RCCL_STATS_PATH, O_RDWR | O_CREAT | O_TRUNC, 0644);
 	if (stats_fd < 0)
 		return;
-
 	if (ftruncate(stats_fd, sizeof(struct odl_rccl_stats)) < 0) {
 		close(stats_fd);
 		stats_fd = -1;
 		return;
 	}
-
 	stats_map = mmap(NULL, sizeof(struct odl_rccl_stats),
 			 PROT_READ | PROT_WRITE, MAP_SHARED, stats_fd, 0);
 	if (stats_map == MAP_FAILED) {
@@ -81,7 +154,6 @@ static void stats_init(void)
 		stats_fd = -1;
 		return;
 	}
-
 	memset(stats_map, 0, sizeof(*stats_map));
 	stats_map->magic = ODL_RCCL_STATS_MAGIC;
 	stats_map->version = ODL_RCCL_STATS_VERSION;
@@ -120,9 +192,47 @@ static inline void stats_record_rx(int size)
 	__atomic_store_n(&stats_map->last_update_ns, clock_mono_ns(), __ATOMIC_RELAXED);
 }
 
+/* Open (or reuse) the shared device handle and wait for the peer link. */
+static rcclResult_t get_shared_handle(int dev, odl_tb5_t *out)
+{
+	rcclResult_t res = rcclSuccess;
+
+	pthread_mutex_lock(&g_lock);
+	if (!g_handle) {
+		if (odl_tb5_open(&g_handle, dev) < 0) {
+			g_handle = NULL;
+			res = rcclSystemError;
+			goto out;
+		}
+		if (odl_tb5_wait_peer(g_handle, 10000) < 0) {
+			odl_tb5_close(g_handle);
+			g_handle = NULL;
+			res = rcclSystemError;
+			goto out;
+		}
+	}
+	g_handle_refs++;
+	*out = g_handle;
+out:
+	pthread_mutex_unlock(&g_lock);
+	return res;
+}
+
+static void put_shared_handle(void)
+{
+	pthread_mutex_lock(&g_lock);
+	if (g_handle && --g_handle_refs == 0) {
+		odl_tb5_close(g_handle);
+		g_handle = NULL;
+	}
+	pthread_mutex_unlock(&g_lock);
+}
+
 static rcclResult_t odl_tb5_init(rcclDebugLogger_t logFunction)
 {
 	odl_logger = logFunction;
+	odl_dbg_init();
+	DBG(1, "init: plugin loaded pid=%d", (int)getpid());
 	stats_init();
 	atexit(stats_cleanup);
 	return rcclSuccess;
@@ -130,42 +240,10 @@ static rcclResult_t odl_tb5_init(rcclDebugLogger_t logFunction)
 
 static rcclResult_t odl_tb5_devices(int *ndev)
 {
-	DIR *dir;
-	struct dirent *entry;
-	char path[256], uuid_buf[64];
-	FILE *fp;
-
-	num_devices = 0;
-	dir = opendir("/sys/bus/thunderbolt/devices");
-	if (!dir) {
-		*ndev = 0;
-		return rcclSuccess;
-	}
-
-	while ((entry = readdir(dir)) != NULL && num_devices < ODL_TB5_MAX_RCCL_DEVICES) {
-		if (strncmp(entry->d_name, "domain", 6) != 0)
-			continue;
-
-		snprintf(path, sizeof(path),
-			 "/sys/bus/thunderbolt/devices/%s/unique_id",
-			 entry->d_name);
-		fp = fopen(path, "r");
-		if (!fp) {
-			snprintf(hw_ids[num_devices], sizeof(hw_ids[0]),
-				 "%s", entry->d_name);
-		} else {
-			if (fgets(uuid_buf, sizeof(uuid_buf), fp)) {
-				uuid_buf[strcspn(uuid_buf, "\n")] = '\0';
-				snprintf(hw_ids[num_devices], sizeof(hw_ids[0]),
-					 "%s", uuid_buf);
-			}
-			fclose(fp);
-		}
-		num_devices++;
-	}
-
-	closedir(dir);
-	*ndev = num_devices;
+	/* Single point-to-point TB link => one usable net device. */
+	num_devices = 1;
+	snprintf(hw_ids[0], sizeof(hw_ids[0]), "odl_tb5_0");
+	*ndev = 1;
 	return rcclSuccess;
 }
 
@@ -175,22 +253,22 @@ static rcclResult_t odl_tb5_getProperties(int dev, rcclNetProperties_v7_t *props
 		return rcclInvalidArgument;
 
 	memset(props, 0, sizeof(*props));
-	snprintf(props->name, sizeof(props->name),
-		 "OdinLink TB5 DMA Ring");
-	snprintf(props->pciPath, sizeof(props->pciPath),
-		 "/sys/bus/thunderbolt");
+	props->name = (char *)"OdinLink-TB5";
+	props->pciPath = (char *)"/sys/bus/thunderbolt";
 	props->guid = (uint64_t)dev;
-	props->ptrSupport = 1;
+	props->ptrSupport = NCCL_PTR_HOST;   /* RCCL stages GPU<->host itself */
 	props->speed = 80000;
 	props->port = dev;
-	props->maxComm = 1;
+	props->latency = 0.0f;
+	props->maxComm = 0x7fffffff;
 	props->maxRecvs = 1;
-
+	props->netDeviceType = 0;            /* NCCL_NET_DEVICE_HOST */
+	props->netDeviceVersion = 0;
+	DBG(1, "getProperties dev=%d name=%s ptrSupport=HOST", dev, props->name);
 	return rcclSuccess;
 }
 
-static rcclResult_t odl_tb5_listen(int dev, void *handle,
-				   void **listenComm)
+static rcclResult_t odl_tb5_listen(int dev, void *handle, void **listenComm)
 {
 	struct odl_tb5_listen_handle *lh;
 
@@ -204,135 +282,333 @@ static rcclResult_t odl_tb5_listen(int dev, void *handle,
 	lh->dev_id = dev;
 	snprintf(lh->hw_id, sizeof(lh->hw_id), "%s", hw_ids[dev]);
 
-	if (handle)
-		memcpy(handle, lh->hw_id, sizeof(lh->hw_id));
+	/* Open the recv stream now (auto id, collision-free) and advertise its
+	 * real id so the peer's connect() can target it as dst. */
+	if (get_shared_handle(dev, &lh->handle) != rcclSuccess) {
+		free(lh);
+		return rcclSystemError;
+	}
+	if (odl_tb5_stream_open(lh->handle, 0, &lh->stream_id) < 0) {
+		put_shared_handle();
+		free(lh);
+		return rcclSystemError;
+	}
 
+	if (handle) {
+		memset(handle, 0, 64);
+		((uint8_t *)handle)[0] = lh->stream_id;
+		memcpy((uint8_t *)handle + 1, lh->hw_id, sizeof(lh->hw_id));
+	}
+
+	DBG(1, "listen  dev=%d -> recv stream_id=%u (lh=%p)", dev, lh->stream_id, (void *)lh);
 	*listenComm = lh;
 	return rcclSuccess;
 }
 
-static rcclResult_t odl_tb5_connect(int dev, void *handle,
-				    void **sendComm, void **recvComm)
+/* Sender side. RCCL v7 passes sendDevComm (device-side handle) which this
+ * CPU-staged plugin does not use — set it to NULL. */
+static rcclResult_t odl_tb5_connect(int dev, void *handle, void **sendComm,
+				    rcclNetDeviceHandle_v7_t **sendDevComm)
 {
 	struct odl_tb5_comm *comm;
-	int ret;
+	uint8_t peer_cid = ((uint8_t *)handle)[0];
+	uint8_t sid = 0;
+
+	if (sendDevComm)
+		*sendDevComm = NULL;
 
 	comm = calloc(1, sizeof(*comm));
 	if (!comm)
 		return rcclSystemError;
 
-	ret = odl_tb5_open(&comm->handle, dev);
-	if (ret < 0) {
+	if (get_shared_handle(dev, &comm->handle) != rcclSuccess) {
 		free(comm);
 		return rcclSystemError;
 	}
 
-	ret = odl_tb5_wait_peer(comm->handle, 5000);
-	if (ret < 0) {
-		odl_tb5_close(comm->handle);
+	/* Local send stream (auto-assigned); target the peer's advertised id. */
+	if (odl_tb5_stream_open(comm->handle, 0, &sid) < 0) {
+		put_shared_handle();
+		free(comm);
+		return rcclSystemError;
+	}
+	comm->stream_id = sid;
+	comm->dst_id = peer_cid;
+	comm->is_send = 1;
+
+	if (comm_start_worker(comm) < 0) {
+		odl_tb5_stream_close(comm->handle, comm->stream_id);
+		put_shared_handle();
 		free(comm);
 		return rcclSystemError;
 	}
 
-	comm->refcount = 2;
+	DBG(1, "connect dev=%d send stream_id=%u -> dst=%u (comm=%p)", dev, sid, peer_cid, (void *)comm);
 	*sendComm = comm;
-	*recvComm = comm;
 	return rcclSuccess;
 }
 
-static rcclResult_t odl_tb5_accept(void *listenComm,
-				   void **recvComm, void **sendComm)
+/* Receiver side. */
+static rcclResult_t odl_tb5_accept(void *listenComm, void **recvComm,
+				   rcclNetDeviceHandle_v7_t **recvDevComm)
 {
 	struct odl_tb5_listen_handle *lh = listenComm;
 	struct odl_tb5_comm *comm;
-	int ret;
+
+	if (recvDevComm)
+		*recvDevComm = NULL;
 
 	comm = calloc(1, sizeof(*comm));
 	if (!comm)
 		return rcclSystemError;
 
-	ret = odl_tb5_open(&comm->handle, lh->dev_id);
-	if (ret < 0) {
+	/* Reuse the recv stream + handle ref already opened in listen(). */
+	comm->handle = lh->handle;
+	comm->stream_id = lh->stream_id;
+	comm->dst_id = 0;
+	comm->is_send = 0;
+	lh->accepted = 1;   /* ref now owned by recvComm */
+
+	if (comm_start_worker(comm) < 0) {
+		odl_tb5_stream_close(comm->handle, comm->stream_id);
+		put_shared_handle();
 		free(comm);
 		return rcclSystemError;
 	}
 
-	ret = odl_tb5_wait_peer(comm->handle, 5000);
-	if (ret < 0) {
-		odl_tb5_close(comm->handle);
-		free(comm);
-		return rcclSystemError;
-	}
-
-	comm->refcount = 2;
-	*sendComm = comm;
+	DBG(1, "accept  recv stream_id=%u (lh=%p comm=%p)", comm->stream_id, listenComm, (void *)comm);
 	*recvComm = comm;
 	return rcclSuccess;
 }
 
 static rcclResult_t odl_tb5_closeListen(void *listenComm)
 {
-	free(listenComm);
+	struct odl_tb5_listen_handle *lh = listenComm;
+
+	if (lh && !lh->accepted && lh->handle) {
+		/* accept() never took ownership — release the recv stream + ref. */
+		odl_tb5_stream_close(lh->handle, lh->stream_id);
+		put_shared_handle();
+	}
+	free(lh);
 	return rcclSuccess;
 }
 
-static rcclResult_t odl_tb5_isend(void *sendComm, void *data,
-				  int size, int tag, void **request)
+/* ── Memory registration (host staging: record only) ───────────────── */
+static rcclResult_t odl_tb5_regMr(void *comm, void *data, int size, int type,
+				  void **mhandle)
 {
-	struct odl_tb5_comm *comm = sendComm;
-	struct odl_tb5_request *req;
-	int ret;
+	struct odl_tb5_mr *mr = calloc(1, sizeof(*mr));
+	(void)comm; (void)type;
+	if (!mr)
+		return rcclSystemError;
+	mr->data = data;
+	mr->size = (size_t)size;
+	*mhandle = mr;
+	return rcclSuccess;
+}
 
-	req = calloc(1, sizeof(*req));
+static rcclResult_t odl_tb5_regMrDmaBuf(void *comm, void *data, size_t size,
+					int type, uint64_t offset, int fd,
+					void **mhandle)
+{
+	(void)offset; (void)fd;
+	return odl_tb5_regMr(comm, data, (int)size, type, mhandle);
+}
+
+static rcclResult_t odl_tb5_deregMr(void *comm, void *mhandle)
+{
+	(void)comm;
+	free(mhandle);
+	return rcclSuccess;
+}
+
+/* Max payload that fits in a single TB frame (frame 4096 - 5B stream hdr).
+ * The kernel's multi-frame reassembly is unreliable, but single-frame
+ * messages are byte-exact, so we chunk every transfer to <= this and send
+ * each chunk as its own atomic single-frame message.  The per-connection
+ * FIFO worker + single stream keep chunks strictly ordered on both ends. */
+#define ODL_CHUNK 4000
+
+/* ── Per-connection FIFO worker ────────────────────────────────────── */
+static void do_transfer(struct odl_tb5_comm *comm, struct odl_tb5_request *req)
+{
+	uint8_t src_id = 0;
+	uint32_t actual = 0;
+	int ret;
+	int off = 0;
+
+	DBG(1, "xfer  START %s comm=%p sid=%u dst=%u size=%d",
+	    req->is_send ? "SEND" : "RECV", (void *)comm, comm->stream_id, comm->dst_id, req->size);
+	if (req->is_send) {
+		/* 4-byte length header (own single frame) tells the receiver
+		 * the exact byte count, then the payload in <=1-frame chunks. */
+		uint32_t hdr = (uint32_t)req->size;
+		DBG(2, "  send hdr sid=%u dst=%u", comm->stream_id, comm->dst_id);
+		ret = odl_tb5_stream_send(comm->handle, comm->stream_id,
+					  comm->dst_id, &hdr, sizeof(hdr));
+		while (ret >= 0 && off < req->size) {
+			int n = req->size - off;
+			if (n > ODL_CHUNK)
+				n = ODL_CHUNK;
+			DBG(2, "  send chunk sid=%u off=%d n=%d", comm->stream_id, off, n);
+			ret = odl_tb5_stream_send(comm->handle, comm->stream_id,
+						  comm->dst_id,
+						  (char *)req->data + off,
+						  (uint32_t)n);
+			off += n;
+		}
+		if (ret < 0)
+			req->failed = 1;
+		else
+			stats_record_tx(req->size);
+		req->done_size = req->size;
+	} else {
+		uint32_t total = 0;
+		DBG(2, "  recv hdr sid=%u", comm->stream_id);
+		ret = odl_tb5_stream_recv(comm->handle, comm->stream_id,
+					  &total, sizeof(total), &src_id, &actual);
+		if (ret < 0 || actual != sizeof(total)) {
+			req->failed = 1;
+		} else {
+			if ((int)total > req->size)
+				total = (uint32_t)req->size;
+			while (off < (int)total) {
+				int n = (int)total - off;
+				if (n > ODL_CHUNK)
+					n = ODL_CHUNK;
+				DBG(2, "  recv chunk sid=%u off=%d n=%d", comm->stream_id, off, n);
+				ret = odl_tb5_stream_recv(comm->handle,
+							  comm->stream_id,
+							  (char *)req->data + off,
+							  (uint32_t)n, &src_id,
+							  &actual);
+				if (ret < 0) {
+					req->failed = 1;
+					break;
+				}
+				off += (int)actual;
+				if (actual == 0)
+					break;
+			}
+			if (!req->failed)
+				stats_record_rx(off);
+		}
+		req->done_size = off;
+	}
+	DBG(1, "xfer  %s   %s comm=%p sid=%u size=%d ret=%d off=%d",
+	    req->failed ? "FAIL" : "DONE", req->is_send ? "SEND" : "RECV",
+	    (void *)comm, comm->stream_id, req->size, ret, off);
+	__atomic_store_n(&req->done, 1, __ATOMIC_RELEASE);
+}
+
+static void *comm_worker(void *arg)
+{
+	struct odl_tb5_comm *comm = arg;
+
+	pthread_mutex_lock(&comm->q_lock);
+	for (;;) {
+		while (!comm->q_head && !comm->stop)
+			pthread_cond_wait(&comm->q_cond, &comm->q_lock);
+		if (!comm->q_head && comm->stop)
+			break;
+		struct odl_tb5_request *req = comm->q_head;
+		comm->q_head = req->next;
+		if (!comm->q_head)
+			comm->q_tail = NULL;
+		pthread_mutex_unlock(&comm->q_lock);
+
+		do_transfer(comm, req);        /* blocking, in FIFO order */
+
+		pthread_mutex_lock(&comm->q_lock);
+	}
+	pthread_mutex_unlock(&comm->q_lock);
+	return NULL;
+}
+
+static int comm_start_worker(struct odl_tb5_comm *comm)
+{
+	pthread_mutex_init(&comm->q_lock, NULL);
+	pthread_cond_init(&comm->q_cond, NULL);
+	comm->q_head = comm->q_tail = NULL;
+	comm->stop = 0;
+	if (pthread_create(&comm->worker, NULL, comm_worker, comm) != 0)
+		return -1;
+	comm->worker_started = 1;
+	return 0;
+}
+
+static void comm_stop_worker(struct odl_tb5_comm *comm)
+{
+	if (!comm->worker_started)
+		return;
+	pthread_mutex_lock(&comm->q_lock);
+	comm->stop = 1;
+	pthread_cond_signal(&comm->q_cond);
+	pthread_mutex_unlock(&comm->q_lock);
+	pthread_join(comm->worker, NULL);
+	pthread_mutex_destroy(&comm->q_lock);
+	pthread_cond_destroy(&comm->q_cond);
+}
+
+static rcclResult_t start_request(struct odl_tb5_comm *comm, void *data,
+				  int size, int is_send, void **request)
+{
+	struct odl_tb5_request *req = calloc(1, sizeof(*req));
+
 	if (!req)
 		return rcclSystemError;
-
-	ret = odl_tb5_send_dmabuf(comm->handle, (int)(intptr_t)data, 0, size);
-	if (ret < 0) {
-		free(req);
-		return rcclSystemError;
-	}
-
-	stats_record_tx(size);
-
+	req->comm = comm;
+	req->data = data;
 	req->size = size;
-	req->done = false;
+	req->is_send = is_send;
+	req->done = 0;
+	req->next = NULL;
+
+	pthread_mutex_lock(&comm->q_lock);
+	if (comm->q_tail)
+		comm->q_tail->next = req;
+	else
+		comm->q_head = req;
+	comm->q_tail = req;
+	pthread_cond_signal(&comm->q_cond);
+	pthread_mutex_unlock(&comm->q_lock);
+
 	*request = req;
 	return rcclSuccess;
 }
 
-static rcclResult_t odl_tb5_irecv(void *recvComm, void *data,
-				  int size, int tag, void **request)
+static rcclResult_t odl_tb5_isend(void *sendComm, void *data, int size,
+				  int tag, void *mhandle, void **request)
 {
-	struct odl_tb5_comm *comm = recvComm;
-	struct odl_tb5_request *req;
-	int ret;
+	struct odl_tb5_comm *c = sendComm;
+	(void)mhandle;
+	DBG(1, "isend   POST comm=%p sid=%u dst=%u size=%d tag=%d", sendComm, c->stream_id, c->dst_id, size, tag);
+	return start_request(sendComm, data, size, 1, request);
+}
 
-	req = calloc(1, sizeof(*req));
-	if (!req)
-		return rcclSystemError;
+static rcclResult_t odl_tb5_irecv(void *recvComm, int n, void **data,
+				  int *sizes, int *tags, void **mhandles,
+				  void **request)
+{
+	struct odl_tb5_comm *c = recvComm;
+	(void)tags; (void)mhandles;
+	/* maxRecvs=1: RCCL posts one buffer per recv. */
+	if (n < 1)
+		return rcclInvalidArgument;
+	DBG(1, "irecv   POST comm=%p sid=%u n=%d size=%d", recvComm, c->stream_id, n, sizes[0]);
+	return start_request(recvComm, data[0], sizes[0], 0, request);
+}
 
-	ret = odl_tb5_recv_dmabuf(comm->handle, (int)(intptr_t)data, 0, size);
-	if (ret < 0) {
-		free(req);
-		return rcclSystemError;
-	}
-
-	stats_record_rx(size);
-
-	req->size = size;
-	req->done = false;
-	*request = req;
+static rcclResult_t odl_tb5_iflush(void *recvComm, int n, void **data,
+				   int *sizes, void **mhandles, void **request)
+{
+	(void)recvComm; (void)n; (void)data; (void)sizes; (void)mhandles;
+	*request = NULL;   /* host memory: nothing to flush */
 	return rcclSuccess;
 }
 
-static rcclResult_t odl_tb5_iflush(void *sendComm, int dev,
-				   void **request)
-{
-	return rcclSuccess;
-}
-
-static rcclResult_t odl_tb5_test(void *request, int *done, int *size)
+static rcclResult_t odl_tb5_test(void *request, int *done, int *sizes)
 {
 	struct odl_tb5_request *req = request;
 
@@ -341,29 +617,31 @@ static rcclResult_t odl_tb5_test(void *request, int *done, int *size)
 		return rcclSuccess;
 	}
 
-	*done = 1;
-	if (size)
-		*size = req->size;
-
-	if (*done) {
+	if (__atomic_load_n(&req->done, __ATOMIC_ACQUIRE)) {
+		*done = 1;
+		if (req->failed) {
+			free(req);
+			return rcclSystemError;
+		}
+		if (sizes)
+			sizes[0] = req->done_size;
 		free(req);
+	} else {
+		*done = 0;
 	}
-
 	return rcclSuccess;
 }
 
 static rcclResult_t odl_tb5_closeSend(void *sendComm)
 {
 	struct odl_tb5_comm *comm = sendComm;
-
 	if (!comm)
 		return rcclSuccess;
-
-	if (__atomic_sub_fetch(&comm->refcount, 1, __ATOMIC_SEQ_CST) == 0) {
-		odl_tb5_close(comm->handle);
-		free(comm);
-	}
-
+	DBG(1, "close   comm=%p sid=%u is_send=%d", (void *)comm, comm->stream_id, comm->is_send);
+	comm_stop_worker(comm);
+	odl_tb5_stream_close(comm->handle, comm->stream_id);
+	put_shared_handle();
+	free(comm);
 	return rcclSuccess;
 }
 
@@ -372,19 +650,42 @@ static rcclResult_t odl_tb5_closeRecv(void *recvComm)
 	return odl_tb5_closeSend(recvComm);
 }
 
+static rcclResult_t odl_tb5_getDeviceMr(void *comm, void *mhandle,
+					void **dptr_mhandle)
+{
+	(void)comm; (void)mhandle;
+	if (dptr_mhandle)
+		*dptr_mhandle = NULL;
+	return rcclSuccess;
+}
+
+static rcclResult_t odl_tb5_irecvConsumed(void *recvComm, int n, void *request)
+{
+	(void)recvComm; (void)n; (void)request;
+	return rcclSuccess;
+}
+
 rcclNet_v7_t rcclNetPlugin_v7 = {
-	.name        = "ODL_TB5",
-	.init        = odl_tb5_init,
-	.devices     = odl_tb5_devices,
+	.name          = "ODL_TB5",
+	.init          = odl_tb5_init,
+	.devices       = odl_tb5_devices,
 	.getProperties = odl_tb5_getProperties,
-	.listen      = odl_tb5_listen,
-	.connect     = odl_tb5_connect,
-	.accept      = odl_tb5_accept,
-	.closeListen = odl_tb5_closeListen,
-	.isend       = odl_tb5_isend,
-	.irecv       = odl_tb5_irecv,
-	.iflush      = odl_tb5_iflush,
-	.test        = odl_tb5_test,
-	.closeSend   = odl_tb5_closeSend,
-	.closeRecv   = odl_tb5_closeRecv,
+	.listen        = odl_tb5_listen,
+	.connect       = odl_tb5_connect,
+	.accept        = odl_tb5_accept,
+	.regMr         = odl_tb5_regMr,
+	.regMrDmaBuf   = odl_tb5_regMrDmaBuf,
+	.deregMr       = odl_tb5_deregMr,
+	.isend         = odl_tb5_isend,
+	.irecv         = odl_tb5_irecv,
+	.iflush        = odl_tb5_iflush,
+	.test          = odl_tb5_test,
+	.closeSend     = odl_tb5_closeSend,
+	.closeRecv     = odl_tb5_closeRecv,
+	.closeListen   = odl_tb5_closeListen,
+	.getDeviceMr   = odl_tb5_getDeviceMr,
+	.irecvConsumed = odl_tb5_irecvConsumed,
 };
+
+/* RCCL's plugin loader dlsym()s the NCCL-prefixed symbol ncclNetPlugin_vN. */
+extern rcclNet_v7_t ncclNetPlugin_v7 __attribute__((alias("rcclNetPlugin_v7")));

--- a/third_party/rccl/net_v7.h
+++ b/third_party/rccl/net_v7.h
@@ -18,48 +18,63 @@ typedef enum {
 
 typedef void (*rcclDebugLogger_t)(int level, const char* fmt, ...);
 
-typedef struct rcclNetProperties_v7 rcclNetProperties_v7_t;
-
-typedef struct rcclNet_v7 {
-  // Name of the network (mainly for logs)
-  const char* name;
-  // Initialize the network.
-  rcclResult_t (*init)(rcclDebugLogger_t logFunction);
-  // Return the number of adapters.
-  rcclResult_t (*devices)(int* ndev);
-  // Get various device properties.
-  rcclResult_t (*getProperties)(int dev, rcclNetProperties_v7_t* props);
-  // Create a listening socket.
-  rcclResult_t (*listen)(int dev, void* handle, void** listenComm);
-  // Connect to a handle.
-  rcclResult_t (*connect)(int dev, void* handle, void** sendComm, void** recvComm);
-  // Accept an incoming connection.
-  rcclResult_t (*accept)(void* listenComm, void** recvComm, void** sendComm);
-  // Close a listening socket.
-  rcclResult_t (*closeListen)(void* listenComm);
-  // Send data to the peer.
-  rcclResult_t (*isend)(void* sendComm, void* data, int size, int tag, void** request);
-  // Receive data from the peer.
-  rcclResult_t (*irecv)(void* recvComm, void* data, int size, int tag, void** request);
-  // Flush outstanding sends.
-  rcclResult_t (*iflush)(void* sendComm, int dev, void** request);
-  // Test whether a request is complete.
-  rcclResult_t (*test)(void* request, int* done, int* size);
-  // Close a send communicator.
-  rcclResult_t (*closeSend)(void* sendComm);
-  // Close a recv communicator.
-  rcclResult_t (*closeRecv)(void* recvComm);
-} rcclNet_v7_t;
+/* Memory pointer types (bitmask in properties.ptrSupport). */
+#define NCCL_PTR_HOST 0x1
+#define NCCL_PTR_CUDA 0x2
+#define NCCL_PTR_DMABUF 0x4
 
 typedef struct rcclNetProperties_v7 {
-  char name[MAX_STR_LEN];
-  char pciPath[MAX_STR_LEN];
+  char* name;        /* NCCL v7: pointer, NOT an inline buffer */
+  char* pciPath;
   uint64_t guid;
   int ptrSupport;
   int speed;
   int port;
+  float latency;
   int maxComm;
   int maxRecvs;
+  int netDeviceType;
+  int netDeviceVersion;
 } rcclNetProperties_v7_t;
+
+/* Opaque device-side comm handle (unused by this CPU-staged plugin). */
+typedef struct rcclNetDeviceHandle_v7 rcclNetDeviceHandle_v7_t;
+
+/*
+ * NCCL/RCCL net plugin API, version 7.  The field order and function
+ * signatures MUST match RCCL's ncclNet_v7_t exactly — RCCL calls each
+ * slot by offset with these argument lists.  In particular regMr /
+ * regMrDmaBuf / deregMr sit between accept and isend, isend/irecv carry
+ * an mhandle, irecv/iflush are multi-buffer (n, arrays), and the table
+ * ends with getDeviceMr / irecvConsumed.
+ */
+typedef struct rcclNet_v7 {
+  const char* name;
+  rcclResult_t (*init)(rcclDebugLogger_t logFunction);
+  rcclResult_t (*devices)(int* ndev);
+  rcclResult_t (*getProperties)(int dev, rcclNetProperties_v7_t* props);
+  rcclResult_t (*listen)(int dev, void* handle, void** listenComm);
+  rcclResult_t (*connect)(int dev, void* handle, void** sendComm,
+                          rcclNetDeviceHandle_v7_t** sendDevComm);
+  rcclResult_t (*accept)(void* listenComm, void** recvComm,
+                         rcclNetDeviceHandle_v7_t** recvDevComm);
+  rcclResult_t (*regMr)(void* comm, void* data, int size, int type,
+                        void** mhandle);
+  rcclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type,
+                              uint64_t offset, int fd, void** mhandle);
+  rcclResult_t (*deregMr)(void* comm, void* mhandle);
+  rcclResult_t (*isend)(void* sendComm, void* data, int size, int tag,
+                        void* mhandle, void** request);
+  rcclResult_t (*irecv)(void* recvComm, int n, void** data, int* sizes,
+                        int* tags, void** mhandles, void** request);
+  rcclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes,
+                         void** mhandles, void** request);
+  rcclResult_t (*test)(void* request, int* done, int* sizes);
+  rcclResult_t (*closeSend)(void* sendComm);
+  rcclResult_t (*closeRecv)(void* recvComm);
+  rcclResult_t (*closeListen)(void* listenComm);
+  rcclResult_t (*getDeviceMr)(void* comm, void* mhandle, void** dptr_mhandle);
+  rcclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
+} rcclNet_v7_t;
 
 #endif // RCCL_NET_V7_H_


### PR DESCRIPTION
## What

Fixes found while bringing up OdinLink as the RCCL network transport for 2-node tensor-parallel vLLM on **AMD Strix Halo (gfx1151)** over a single USB4/Thunderbolt cable. With these, distributed TP=2 Llama-3.1-8B **serves over OdinLink** and beats TCP-over-`thunderbolt0` by ~17–26% on decode.

**1. driver: RX-queue overflow (the blocker) + RCU-safe stream lookup**
Per-stream `rx_queue_max` was 256, but a ~1 MB message chunks to ~264 frames (1 frame = 1 `rx_msg`). Under sustained concurrent load the sender runs >256 frames ahead of a receiver that is also sending, the queue fills, and `odl_tb5_rx_callback()` **silently drops** the overflow — there is no flow control/backpressure. Any consumer that assumes lossless in-order delivery (the RCCL plugin, and the natural assumption for a "stream") then desyncs permanently: RCCL recv blocks forever → vLLM hangs at warmup. Interim fix: raise the cap to 65536. Also makes the stream lookup RCU-safe (`hash_*_rcu` + `kref_get_unless_zero`, watermark clamp) to avoid lockups under stream create/destroy churn.

**2. rccl: `ncclNet_v7` ABI fix + host-staged plugin rewrite**
`third_party/rccl/net_v7.h` was ABI-incompatible with real NCCL/RCCL v7 (omitted `regMr/regMrDmaBuf/deregMr`; `char[128]` vs `char*` properties) → RCCL dereferenced a string as a pointer and segfaulted on the first collective. Corrected the struct and rewrote the plugin against it: host-staged (`NCCL_PTR_HOST`), per-connection FIFO worker, single-frame chunking + 4-byte length header, plus opt-in `ODL_DEBUG` tracing (which is what root-caused #1).

**3. add `odl_stress.c`** — RCCL-free reproduction of the RX-queue desync.

## Repro (no RCCL/GPU needed)

```
gcc -O2 -o odl_stress odl_stress.c -Ilib/include -Lbuild/lib -lodl_tb5 -lpthread
# both nodes (needs cma=1G for the default 16MB rings):
./odl_stress duplex 16 1048576 5000
```
Without the fix, one node floods `HDR MISMATCH (DESYNC)` and hangs; with it, byte-perfect on both.

## Honest notes / open design questions

- The queue bump is a **pragmatic interim fix** — the proper fix is **credit-based end-to-end flow control** so frames are never silently dropped (a bigger cap only widens the window under an arbitrarily slow reader). Would value your take on where to implement that.
- Framing could be made **self-synchronizing** (magic + seq) so any future loss is a loud error rather than a silent hang.
- The plugin stages through host memory (`NCCL_PTR_HOST`); a **GPU-direct dmabuf** path is a further perf lever. (Our measured win is latency; on our cable bulk bandwidth is ~9 Gbit/s, but that's a **USB4v1 cable limit** — our routers are `gen=4`/v2-capable and your own USB4v2 benchmark shows ~43 Gb/s, so a TB5 cable should scale it.)

Flagging these rather than presenting the PR as final — happy to iterate or split it up however you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
