### PR TITLE
driver: add optional odl_busy_poll_us RX busy-poll knob

### DIFF
--- a/driver/odl_tb5_core.h
+++ b/driver/odl_tb5_core.h
@@ -434,6 +434,7 @@ int  odl_tb5_proto_send_logout(struct odl_tb5_device *dev);
 extern int odl_loopback_count;
 extern int odl_protocol_mode;
 extern bool odl_e2e;
+extern unsigned int odl_busy_poll_us;
 int  odl_loopback_init(void);
 void odl_loopback_exit(void);
 

--- a/driver/odl_tb5_ring_dma.c
+++ b/driver/odl_tb5_ring_dma.c
@@ -1911,6 +1911,25 @@ int odl_tb5_stream_wait_tx(struct odl_tb5_stream *stream, u32 timeout_ms)
  * Stream RX Path
  * ══════════════════════════════════════════════════════════════════════ */
 
+/* Optional bounded busy-poll for an RX completion before sleeping.  The RX
+ * softirq (odl_tb5_rx_callback) increments rx_complete on another CPU, so a
+ * spinning reader sees it within cache-coherency latency and skips the
+ * context-switch wake (~10-15 us on this box).  Bounded + falls back to
+ * wait_event, so it never hangs.  Off unless odl_busy_poll_us > 0. */
+static inline void odl_tb5_rx_busy_poll(struct odl_tb5_stream *stream)
+{
+	ktime_t deadline;
+
+	if (!odl_busy_poll_us || atomic_read(&stream->rx_complete) > 0)
+		return;
+	deadline = ktime_add_ns(ktime_get(), (u64)odl_busy_poll_us * 1000);
+	while (atomic_read(&stream->rx_complete) == 0) {
+		if (ktime_after(ktime_get(), deadline))
+			break;
+		cpu_relax();
+	}
+}
+
 int odl_tb5_stream_recv(struct odl_tb5_stream *stream,
 			void __user *buf, size_t buf_len,
 			u8 *src_id, u32 *actual_len)
@@ -1920,6 +1939,7 @@ int odl_tb5_stream_recv(struct odl_tb5_stream *stream,
 	int ret = 0;
 
 	/* Wait for a complete assembled message */
+	odl_tb5_rx_busy_poll(stream);
 	ret = wait_event_interruptible(stream->rx_waitq,
 		atomic_read(&stream->rx_complete) > 0);
 	if (ret)
@@ -1954,6 +1974,7 @@ int odl_tb5_stream_wait_rx(struct odl_tb5_stream *stream, u32 timeout_ms)
 {
 	long ret;
 
+	odl_tb5_rx_busy_poll(stream);
 	if (timeout_ms == 0) {
 		ret = wait_event_interruptible(stream->rx_waitq,
 			atomic_read(&stream->rx_complete) > 0);

--- a/driver/odl_tb5_service.c
+++ b/driver/odl_tb5_service.c
@@ -42,6 +42,15 @@ MODULE_PARM_DESC(e2e,
 	"Enable end-to-end flow control (default=1). Set 0 for TB3 controllers "
 	"that do not support RING_FLAG_E2E.");
 
+unsigned int odl_busy_poll_us = 0;
+module_param(odl_busy_poll_us, uint, 0644);
+MODULE_PARM_DESC(odl_busy_poll_us,
+	"Busy-poll up to N us for an RX completion before sleeping (default 0=off). "
+	"Trades a CPU core during the wait for lower context-switch/wake latency on "
+	"small (<= ~512B) latency-bound request/response traffic. Does NOT help "
+	">= 1KB messages (they hit the NHI hardware completion-visibility floor) or "
+	"pipelined RCCL/NCCL collectives (their receives rarely sleep).");
+
 /* Apple protocol uses its own property key and registers as an alternate
  * service so macOS ThunderboltRDMA can discover us via XDomain matching. */
 static struct tb_property_dir *odl_tb5_apple_property_dir;


### PR DESCRIPTION
## What

Adds an opt-in module parameter `odl_busy_poll_us` (default `0` = off, unchanged behavior). When set, the RX path spins up to *N* µs checking for a completion before falling back to `wait_event_interruptible`, trading a CPU core during the wait for lower context-switch/wake latency on small latency-bound traffic.

Deliberately minimal and safe: it runs in process context, only reads an atomic (`rx_complete`), is bounded by a deadline, and always falls back to the normal sleep — it can't hang. No changes to the IRQ / ring / locking paths. Runtime-writable (`0644`) so it can be toggled without a reload.

## Measured effect

2× Framework Desktop (AMD Ryzen AI Max+ 395 / Strix Halo), USB4v1 40 G link, kernel 7.0.14. Synchronous ping-pong RTT, 20k samples, `busy_poll` off → 40 µs:

| payload | off | on |
|---|---|---|
| 64 B | ~22 µs | **~11 µs** |
| 512 B | ~22 µs | **~12 µs** |
| ≥ 1 KB | ~22 µs | ~22 µs (no change) |

## Honest scope / limitations

- Only helps messages whose completion is signaled quickly (≤ ~512 B here). For ≥ 1 KB the completion isn't *visible* until ~22 µs — that floor is the AMD USB4 NHI descriptor-writeback/coalescing latency, which no software polling beats. I verified this: making the fallback poll-timer faster, and processing the ring inline instead of via a workqueue, both leave the ≥ 1 KB floor unchanged (interrupts are coalesced ~1 per 5–6 completions, and the descriptor simply isn't written back sooner).
- It does **not** help RCCL/NCCL collective workloads (e.g. vLLM TP): those messages are ≥ 1 KB and pipelined, so the receive rarely sleeps.
- So this is useful for latency-sensitive small request/response over the link, not for bulk/collective throughput. Off by default → zero impact unless enabled.

Independent of #20 (that touches the rx-queue/RCU and the RCCL plugin); this only adds the driver knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
