### PR TITLE
fix: address Strix Halo / Proxmox field findings (issue #23)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ mkdir build && cd build && cmake .. && make -j$(nproc)
 
 ## Module Parameters
 
-`ring_size=4096` (range 64–16384, power of 2, 4 KB per entry). `e2e=1` (default, RING_FLAG_E2E). Pass `e2e=0` for TB3 controllers that don't support end-to-end flow control. `protocol=0` (OdinLink, default) or `1` (Apple/macOS compat).
+`odl_ring_size=4096` (range 64–16384, power of 2, 4 KB per entry; probe auto-downgrades on DMA `-ENOMEM` / `iommu=pt`). `e2e=1` (default, RING_FLAG_E2E). Pass `e2e=0` for TB3 controllers that don't support end-to-end flow control. `protocol=0` (OdinLink, default) or `1` (Apple/macOS compat). `ODL_TB5_PROTOCOL_VER` is exchanged at login — mismatched revs refuse READY.
 
 ## Gotchas
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,16 +9,19 @@ include_directories(third_party/rccl)
 # =============================================================================
 # Consolidated dependency check
 # =============================================================================
+# Missing items are tracked as "pkg: <module>" or "tool: <name>" so the
+# remediation message is distro-agnostic (issue #23: Fedora containers do not
+# speak `apt install`).
 set(ODL_MISSING_DEPS "")
 
 find_program(KERNEL_GCC NAMES gcc-15 gcc-14 gcc QUIET)
 if(NOT KERNEL_GCC)
-    list(APPEND ODL_MISSING_DEPS "gcc-14")
+    list(APPEND ODL_MISSING_DEPS "tool: gcc-14|gcc-15|gcc (matching kernel)")
 endif()
 
-find_program(PKG_CONFIG_EXE NAMES pkg-config QUIET)
+find_program(PKG_CONFIG_EXE NAMES pkg-config pkgconf QUIET)
 if(NOT PKG_CONFIG_EXE)
-    list(APPEND ODL_MISSING_DEPS "pkg-config")
+    list(APPEND ODL_MISSING_DEPS "tool: pkg-config (Debian) / pkgconf (Fedora)")
 endif()
 
 # gdbus-codegen is required only when building the daemon (checked in daemon/CMakeLists.txt)
@@ -28,15 +31,22 @@ option(BUILD_DAEMON "Build OdinLink TB5 system daemon" ON)
 option(BUILD_TRAY   "Build OdinLink TB5 tray application" ON)
 find_program(GDBUS_CODEGEN_EXE NAMES gdbus-codegen QUIET)
 if(NOT GDBUS_CODEGEN_EXE AND BUILD_DAEMON)
-    list(APPEND ODL_MISSING_DEPS "libglib2.0-dev-bin")
+    list(APPEND ODL_MISSING_DEPS "tool: gdbus-codegen (pkg: libglib2.0-dev-bin / glib2-devel)")
 endif()
 
-# Kernel module build — optional. Skip header check when building userspace only.
+# Kernel module build — optional. If headers are absent (typical container
+# userspace-only build), default BUILD_KERNEL_MODULE off instead of failing.
 option(BUILD_KERNEL_MODULE "Build the odl_tb5 kernel module" ON)
-if(BUILD_KERNEL_MODULE AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     execute_process(COMMAND uname -r OUTPUT_VARIABLE KERNEL_RELEASE OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT EXISTS "/lib/modules/${KERNEL_RELEASE}/build")
-        list(APPEND ODL_MISSING_DEPS "linux-headers-${KERNEL_RELEASE}")
+    set(ODL_KERNEL_BUILD_DIR "/lib/modules/${KERNEL_RELEASE}/build")
+    if(BUILD_KERNEL_MODULE AND NOT EXISTS "${ODL_KERNEL_BUILD_DIR}")
+        message(STATUS
+            "Kernel headers not found at ${ODL_KERNEL_BUILD_DIR} — "
+            "defaulting BUILD_KERNEL_MODULE=OFF (userspace-only build). "
+            "Install linux-headers-${KERNEL_RELEASE} (or distro equivalent) "
+            "and reconfigure with -DBUILD_KERNEL_MODULE=ON to build the driver.")
+        set(BUILD_KERNEL_MODULE OFF CACHE BOOL "Build the odl_tb5 kernel module" FORCE)
     endif()
 endif()
 
@@ -44,57 +54,57 @@ if(PKG_CONFIG_EXE)
     find_package(PkgConfig QUIET)
     if(PkgConfig_FOUND)
         pkg_check_modules(_CHK_GLIB2 QUIET glib-2.0>=2.56)
-        if(NOT _CHK_GLIB2_FOUND)
-            list(APPEND ODL_MISSING_DEPS "libglib2.0-dev")
+        if(NOT _CHK_GLIB2_FOUND AND BUILD_DAEMON)
+            list(APPEND ODL_MISSING_DEPS "pkg: glib-2.0 (Debian: libglib2.0-dev, Fedora: glib2-devel)")
         endif()
         if(BUILD_TRAY)
             pkg_check_modules(_CHK_GTK3 QUIET gtk+-3.0>=3.22)
             if(NOT _CHK_GTK3_FOUND)
-                list(APPEND ODL_MISSING_DEPS "libgtk-3-dev")
+                list(APPEND ODL_MISSING_DEPS "pkg: gtk+-3.0 (Debian: libgtk-3-dev, Fedora: gtk3-devel)")
             endif()
             pkg_check_modules(_CHK_APPIND QUIET ayatana-appindicator3-0.1)
             if(NOT _CHK_APPIND_FOUND)
-                list(APPEND ODL_MISSING_DEPS "libayatana-appindicator3-dev")
+                list(APPEND ODL_MISSING_DEPS "pkg: ayatana-appindicator3-0.1 (Debian: libayatana-appindicator3-dev)")
             endif()
         endif()
         # Optional
         pkg_check_modules(_CHK_FUSE3 QUIET fuse3>=3.1)
         if(NOT _CHK_FUSE3_FOUND)
-            message(STATUS "Optional: libfuse3-dev not found (distributed file access disabled)")
+            message(STATUS "Optional: fuse3 not found (distributed file access disabled)")
         endif()
         pkg_check_modules(_CHK_OPENSSL QUIET libcrypto)
         if(NOT _CHK_OPENSSL_FOUND)
-            message(STATUS "Optional: libssl-dev not found (SHA-256 sync disabled)")
+            message(STATUS "Optional: libcrypto not found (SHA-256 sync disabled)")
         endif()
     endif()
 else()
-    list(APPEND ODL_MISSING_DEPS "libglib2.0-dev" "libgtk-3-dev" "libayatana-appindicator3-dev")
+    if(BUILD_DAEMON OR BUILD_TRAY)
+        list(APPEND ODL_MISSING_DEPS "tool: pkg-config (needed to probe glib/gtk)")
+    endif()
 endif()
 
 list(REMOVE_DUPLICATES ODL_MISSING_DEPS)
 if(ODL_MISSING_DEPS)
-    string(REPLACE ";" " " _DEPS_STR "${ODL_MISSING_DEPS}")
+    string(REPLACE ";" "\n    - " _DEPS_STR "${ODL_MISSING_DEPS}")
     message(WARNING
         "\n"
         "============================================================\n"
-        "  Missing build dependencies!\n"
+        "  Missing optional/component build dependencies:\n"
         "\n"
-        "  Run:\n"
-        "    sudo apt install ${_DEPS_STR}\n"
+        "    - ${_DEPS_STR}\n"
         "\n"
-        "  Then re-run cmake.\n"
+        "  Daemon/tray auto-disable when their deps are absent.\n"
+        "  Userspace-only (e.g. container consumers):\n"
+        "    cmake .. -DBUILD_KERNEL_MODULE=OFF -DBUILD_DAEMON=OFF -DBUILD_TRAY=OFF\n"
+        "  Fedora container example:\n"
+        "    dnf install -y rdma-core-devel libibverbs-utils pkgconf-pkg-config make gcc cmake\n"
         "============================================================\n")
-    # Fail only if a required dep is missing (not optional fuse3/openssl)
-    if(BUILD_KERNEL_MODULE)
-        if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-           (NOT KERNEL_GCC OR NOT PKG_CONFIG_EXE OR NOT GDBUS_CODEGEN_EXE
-            OR NOT EXISTS "/lib/modules/${KERNEL_RELEASE}/build"))
-            message(FATAL_ERROR "Cannot continue without required dependencies.")
-        endif()
-    else()
-        if(NOT PKG_CONFIG_EXE)
-            message(FATAL_ERROR "Cannot continue without required dependencies.")
-        endif()
+    # Hard-fail only when pkg-config itself is missing and we cannot build
+    # anything useful (daemon/tray already soft-disable; kernel already off).
+    if(NOT PKG_CONFIG_EXE AND (BUILD_DAEMON OR BUILD_TRAY))
+        message(STATUS "pkg-config missing — disabling BUILD_DAEMON and BUILD_TRAY")
+        set(BUILD_DAEMON OFF)
+        set(BUILD_TRAY OFF)
     endif()
 endif()
 if(NOT ODL_MISSING_DEPS)

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -237,14 +237,14 @@ build/verbs/tests/test_verbs_mock_loopback
 ```bash
 # Machine A:
 sudo insmod driver/odl_tb5.ko
-build/cli/odl_tb5_cli --server --device 0
+build/cli/odl_tb5_cli server -d 0
 
-# Machine B:
+# Machine B (wait for "odl_tb5: entering READY state"):
 sudo insmod driver/odl_tb5.ko
-build/cli/odl_tb5_cli --client --device 0 --test bandwidth
+build/cli/odl_tb5_cli client -d 0 -t bandwidth
 
 # Or via verbs:
-build/verbs/tests/test_verbs_basic
+LD_PRELOAD=build/verbs/libodl_tb5_verbs.so build/verbs/tests/test_verbs_basic
 ```
 
 ### Mac ↔ Linux (future — needs protocol matching)

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ OdinLink turns a Thunderbolt cable into a high-speed RDMA interconnect between m
 | 🟢 | rdma-core plugin (`libodl_tb5-rdmav34.so`) | Auto-discovered by `ibv_devinfo` |
 | 🟢 | Async I/O | `poll()` + `O_NONBLOCK` ioctls end-to-end |
 | 🟢 | No-cable testing | `loopback=1` module param + mock library |
-| 🟢 | NCCL verbs transport | NCCL's built-in `NCCL_NET_PLUGIN=IB` transport auto-discovers ODL via `ibv_get_device_list` |
-| 🟡 | NCCL custom plugin | DMA-buf zero-copy path (legacy, use verbs transport instead) |
+| 🟢 | RCCL/NCCL net plugin | **Supported GPU path** — `librccl-net.so` / `libnccl-net-ODL_TB5.so` (see [`docs/GPU.md`](docs/GPU.md)) |
+| 🟡 | NCCL verbs / IB transport | Works only with `LD_PRELOAD=libodl_tb5_verbs.so` health checks; RCCL `dlopen`s libibverbs and **bypasses** preload — use the net plugin |
+| 🟡 | rdma-core provider plugin | Needs a sysfs RDMA device to load; inert on OdinLink-only hosts — use `LD_PRELOAD` for `ibv_devinfo` |
 | 🟡 | Async DMA-buf | Needs callback-based cleanup — stream path is already async via poll() |
 
 ## Quick Start
@@ -53,14 +54,23 @@ build/verbs/tests/test_verbs_basic
 ```bash
 # Machine A:
 sudo insmod driver/odl_tb5.ko
-build/cli/odl_tb5_cli --server --device 0
+build/cli/odl_tb5_cli server -d 0
 
-# Machine B:
+# Machine B (wait for dmesg "entering READY state" first):
 sudo insmod driver/odl_tb5.ko
-build/cli/odl_tb5_cli --client --device 0 --test bandwidth
+build/cli/odl_tb5_cli client -d 0 -t bandwidth -b 64K,1M,4M
 ```
 
-Full install guide → [`docs/INSTALL.md`](docs/INSTALL.md)
+### RCCL (AMD) — use the net plugin, not verbs/IB
+
+```bash
+cmake --build . --target rccl_net_odl_tb5
+# Build tree already has librccl-net.so symlink; or:
+export LD_LIBRARY_PATH=$PWD/rccl:$PWD/lib:$LD_LIBRARY_PATH
+# Confirm logs say:  Using network ODL_TB5   (NOT Socket)
+```
+
+Full install guide → [`docs/INSTALL.md`](docs/INSTALL.md) · GPU → [`docs/GPU.md`](docs/GPU.md)
 
 ## Architecture
 
@@ -204,16 +214,21 @@ Exercises: device discovery, context open, PD/MR/CQ/QP lifecycle, post_send/post
 
 ```bash
 # Machine A:
-build/cli/odl_tb5_cli --server --device 0
+build/cli/odl_tb5_cli server -d 0
 
-# Machine B (wait for server to be ready):
-build/cli/odl_tb5_cli --client --device 0 --test bandwidth
+# Machine B (wait for dmesg: "odl_tb5: entering READY state"):
+build/cli/odl_tb5_cli client -d 0 -t bandwidth
 ```
 
 **5. ibv_devinfo discovery**
 
 ```bash
-ibv_devinfo     # should list an odl_tb5 device
+# Preferred health check on OdinLink-only hosts (no other RDMA NIC):
+LD_PRELOAD=build/verbs/libodl_tb5_verbs.so ibv_devinfo
+
+# The rdma-core directory plugin (libodl_tb5-rdmav34.so) only loads when
+# sysfs already exposes an unclaimed RDMA device — on pure OdinLink machines
+# it is inert. See docs/TROUBLESHOOTING.md.
 ```
 
 ## Module Parameters
@@ -223,14 +238,15 @@ ibv_devinfo     # should list an odl_tb5 device
 | `e2e=0` | 1 (on) | Disables end-to-end flow control handshake. **Only needed for old TB3 controllers** that choke on E2E. TB4/TB5 leave this alone. |
 | `loopback=1` | 0 (off) | Creates fake devices with no cable — data loops back inside your own machine. For testing without a peer. |
 | `protocol=1` | 0 (OdinLink) | Switches to Apple's protocol ID (0xFA57) so macOS peers can discover OdinLink. For Mac↔Linux only. |
-| `ring_size=1024` | 4096 | Number of DMA packet slots per ring. Larger = smoother bursts, more RAM. Fine at 4096 for all TB generations. Lower for RAM-constrained machines. |
+| `odl_ring_size=1024` | 4096 | Number of DMA packet slots per ring. Larger = smoother bursts, more RAM. On `iommu=pt` (identity IOMMU) hosts the default may fail to allocate — use 1024, or let probe auto-downgrade. |
 
 ```bash
 # Examples:
-sudo insmod driver/odl_tb5.ko                  # TB4/TB5, default everything
-sudo insmod driver/odl_tb5.ko e2e=0            # old TB3 controller
-sudo insmod driver/odl_tb5.ko loopback=1        # no cable, just testing
-sudo insmod driver/odl_tb5.ko protocol=1        # talk to macOS
+sudo insmod driver/odl_tb5.ko                       # TB4/TB5, default everything
+sudo insmod driver/odl_tb5.ko e2e=0                 # old TB3 controller
+sudo insmod driver/odl_tb5.ko loopback=1            # no cable, just testing
+sudo insmod driver/odl_tb5.ko protocol=1            # talk to macOS
+sudo insmod driver/odl_tb5.ko odl_ring_size=1024    # iommu=pt / RAM-constrained
 ```
 
 ## Debug

--- a/cli/src/odl_tb5_cli_client.c
+++ b/cli/src/odl_tb5_cli_client.c
@@ -57,12 +57,30 @@ static int run_single_test(odl_tb5_t handle, uint8_t sid, uint8_t dst,
 
 	switch (test_type) {
 	case ODL_TEST_BANDWIDTH:
-		ret = send_test_request(handle, sid, dst, params, test_type,
-					params->block_sizes[0]);
-		if (ret < 0)
-			return ret;
+		/*
+		 * One TEST_REQ per block size. The bandwidth client used to
+		 * loop TEST_START for every size under a single TEST_REQ, but
+		 * the server returns after one size — so the next TEST_START
+		 * hit the server main loop as a non-REQ message and the
+		 * following data frames failed with "Protocol error" (issue #23).
+		 */
+		for (int i = 0; i < params->num_block_sizes; i++) {
+			struct odl_cli_params one = *params;
 
-		ret = odl_cli_bandwidth_client(handle, sid, dst, params);
+			one.block_sizes[0] = params->block_sizes[i];
+			one.num_block_sizes = 1;
+
+			printf("\n--- Bandwidth Test (block=%u) ---\n",
+			       one.block_sizes[0]);
+			ret = send_test_request(handle, sid, dst, &one,
+						test_type, one.block_sizes[0]);
+			if (ret < 0)
+				return ret;
+
+			ret = odl_cli_bandwidth_client(handle, sid, dst, &one);
+			if (ret < 0)
+				return ret;
+		}
 		break;
 
 	case ODL_TEST_LATENCY:

--- a/cli/src/odl_tb5_cli_main.c
+++ b/cli/src/odl_tb5_cli_main.c
@@ -61,10 +61,11 @@ static void parse_block_sizes(const char *str, struct odl_cli_params *p)
 	snprintf(buf, sizeof(buf), "%s", str);
 	p->num_block_sizes = 0;
 
-	tok = strtok_r(buf, ",", &saveptr);
+	/* Accept comma or slash separators (e.g. 4K,64K,1M or 4K/64K/1M). */
+	tok = strtok_r(buf, ",/", &saveptr);
 	while (tok && p->num_block_sizes < 16) {
 		p->block_sizes[p->num_block_sizes++] = parse_size(tok);
-		tok = strtok_r(NULL, ",", &saveptr);
+		tok = strtok_r(NULL, ",/", &saveptr);
 	}
 }
 

--- a/daemon/src/odl_tb5_daemon_test.c
+++ b/daemon/src/odl_tb5_daemon_test.c
@@ -305,14 +305,21 @@ static int daemon_run_single_test(odl_tb5_t handle, uint8_t sid, uint8_t dst,
 
 	switch (test_type) {
 	case ODL_TEST_BANDWIDTH:
+		/* One TEST_REQ + single-size client run per block size.
+		 * bandwidth_client loops TEST_START over num_block_sizes, so
+		 * pass a one-element params or the server sees a bare
+		 * TEST_START and fails with Protocol error (issue #23). */
 		for (int i = 0; i < params->num_block_sizes; i++) {
+			struct odl_cli_params one = *params;
+
+			one.block_sizes[0] = params->block_sizes[i];
+			one.num_block_sizes = 1;
 			ret = daemon_send_test_request(handle, sid, dst,
-						       params, test_type,
-						       params->block_sizes[i]);
+						       &one, test_type,
+						       one.block_sizes[0]);
 			if (ret < 0)
 				return ret;
-			ret = odl_cli_bandwidth_client(handle, sid, dst,
-						       params);
+			ret = odl_cli_bandwidth_client(handle, sid, dst, &one);
 			if (ret < 0)
 				return ret;
 		}

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -1,55 +1,94 @@
 # GPU Usage
 
-## RCCL (AMD ROCm)
+## RCCL (AMD ROCm) — **supported path: net plugin**
+
+RCCL does **not** discover OdinLink through `NCCL_NET_PLUGIN=IB` / verbs.
+It `dlopen`s `libibverbs.so.1` and resolves symbols from that handle, so
+`LD_PRELOAD=libodl_tb5_verbs.so` is bypassed. If the net plugin is missing,
+RCCL silently falls back to TCP sockets (~4× slower) with no error.
+
+### Build and install the plugin
 
 ```bash
+cmake --build . --target rccl_net_odl_tb5
+# Build dir also has librccl-net.so → librccl_net_odl_tb5.so (RCCL's probe name)
+```
+
+```bash
+# Option A — plugin directory (RCCL probes librccl-net.so there)
+export LD_LIBRARY_PATH=/path/to/build/rccl:/path/to/build/lib:$LD_LIBRARY_PATH
+# Optional name pin used by some RCCL builds:
 export RCCL_NET_PLUGIN=ODL_TB5
 export RCCL_PLUGIN_DIR=/path/to/build/rccl
 
-# Your RCCL/ROCm application will use TB5 automatically
+# Option B — system install (also installs as librccl-net.so)
+sudo cmake --install build --component rccl
 ```
+
+### Confirm you are on the fast path
+
+With `NCCL_DEBUG=INFO` / `RCCL_DEBUG=INFO` you want:
+
+```
+NCCL INFO NET/Plugin: Loaded net plugin ODL_TB5 (v7)
+NCCL INFO Using network ODL_TB5
+```
+
+If you see `Using network Socket` instead, the plugin was not found —
+collectives still complete, just slowly. Fix `LD_LIBRARY_PATH` /
+`RCCL_PLUGIN_DIR` so `librccl-net.so` is visible.
 
 The RCCL plugin exports shared-memory statistics at `/run/odl_tb5/rccl_stats`.
 The daemon reads these and exposes them via D-Bus; the tray app displays
 TX/RX bytes, operation counts, and uptime in a dedicated RCCL Stats window.
 
-## NCCL (NVIDIA CUDA / PyTorch)
+### `iommu=pt` note (virtualisation hosts)
 
-### Option 1: Built-in Verbs Transport (Recommended)
+RCCL may print:
 
-NCCL has a built-in `IB` (InfiniBand Verbs) transport that discovers RDMA
-devices automatically via `ibv_get_device_list`. Once the OdinLink verbs
-provider plugin is installed, NCCL can use it without any custom plugin.
-
-```bash
-# Install provider plugin (one-time)
-sudo cp build/verbs/libodl_tb5-rdmav34.so /usr/lib/aarch64-linux-gnu/libibverbs/
-
-# NCCL discovers ODL automatically via verbs
-export NCCL_NET_PLUGIN=IB
-export NCCL_IB_HCA=odl_tb5               # Restrict to ODL device
-export NCCL_IB_TIMEOUT=22
-export NCCL_IB_RETRY_CNT=7
-
-# Run your NCCL application
-torchrun --nproc_per_node=1 --nnodes=2 \
-    --node_rank=0 --master_addr=192.168.1.1 --master_port=12345 \
-    your_training_script.py
+```
+NCCL WARN Missing "iommu=pt" from kernel command line ...
 ```
 
-The verbs provider implements all operations NCCL's IB transport needs:
-`ibv_reg_mr`, `ibv_create_qp`, `ibv_post_send`, `ibv_post_recv`,
-`ibv_poll_cq`. This is the standard, well-tested path.
+On single-GPU Strix Halo / Proxmox nodes that warning is often wrong for
+OdinLink: `iommu=pt` puts the Thunderbolt NHI in an **identity** IOMMU
+domain where the default `odl_ring_size=4096` (16 MB contiguous) fails to
+allocate. Prefer translated IOMMU, or load with `odl_ring_size=1024`.
 
-### Option 2: Custom Plugin (Legacy)
+## NCCL (NVIDIA CUDA / PyTorch)
 
-The custom NCCL plugin provides a DMA-buf-based zero-copy path for CUDA
-memory. It bypasses the verbs stack for direct kernel driver access.
+### Option 1: Custom net plugin (recommended for multi-node TB)
 
 ```bash
 export NCCL_NET_PLUGIN=ODL_TB5
 export NCCL_PLUGIN_DIR=/path/to/build/nccl
+export NCCL_DEBUG=INFO   # confirm "Using network ODL_TB5"
 ```
+
+### Option 2: Built-in Verbs / IB transport
+
+NCCL's built-in `IB` transport discovers RDMA devices via
+`ibv_get_device_list`. This only works if the OdinLink device is visible
+to libibverbs:
+
+- **`LD_PRELOAD=libodl_tb5_verbs.so`** works for tools like `ibv_devinfo`
+- The **rdma-core directory plugin** (`libodl_tb5-rdmav34.so`) only loads
+  when sysfs already has an unclaimed RDMA device — on OdinLink-only
+  hosts it is inert
+- Many production stacks `dlopen` libibverbs and ignore `LD_PRELOAD`
+  (same footgun as RCCL)
+
+```bash
+# x86_64 install path for the directory plugin (if you have other RDMA NICs)
+sudo cp build/verbs/libodl_tb5-rdmav34.so /usr/lib/x86_64-linux-gnu/libibverbs/
+
+export NCCL_NET_PLUGIN=IB
+export NCCL_IB_HCA=odl_tb5
+export NCCL_IB_TIMEOUT=22
+export NCCL_IB_RETRY_CNT=7
+```
+
+Prefer Option 1 (net plugin) unless you have verified IB discovery.
 
 ### Prerequisites
 - NVIDIA GPU with `nvidia-drm` modeset enabled (`nvidia-drm.modeset=1`)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -59,14 +59,30 @@ CMake reports which components are enabled:
 -- BUILD_TRAY:   ON
 ```
 
+## Userspace-Only Build (containers)
+
+When the module runs on the host and only userspace is needed inside a
+container (no kernel headers, no GUI):
+
+```bash
+# Fedora
+dnf install -y rdma-core-devel libibverbs-utils pkgconf-pkg-config make gcc cmake
+
+cmake .. -DBUILD_VERBS=ON -DBUILD_KERNEL_MODULE=OFF -DBUILD_DAEMON=OFF -DBUILD_TRAY=OFF
+cmake --build . --target odl_tb5 odl_tb5_verbs rccl_net_odl_tb5 -j$(nproc)
+```
+
+If `/lib/modules/$(uname -r)/build` is missing, CMake defaults
+`BUILD_KERNEL_MODULE=OFF` instead of hard-failing.
+
 ## Load the Kernel Module
 
 ```bash
 # Load with default ring size (4096 entries = 16 MB per batch)
 sudo insmod driver/odl_tb5.ko
 
-# Or load with custom ring size (power of 2, 64-16384)
-sudo insmod driver/odl_tb5.ko ring_size=16384
+# Custom ring size (power of 2, 64-16384). Name is odl_ring_size, not ring_size.
+sudo insmod driver/odl_tb5.ko odl_ring_size=1024   # recommended with iommu=pt
 
 # Loopback mode (no cable needed)
 sudo insmod driver/odl_tb5.ko loopback=1
@@ -74,8 +90,9 @@ sudo insmod driver/odl_tb5.ko loopback=1
 # Apple-compatible protocol mode
 sudo insmod driver/odl_tb5.ko protocol=1
 
-# Verify
+# Verify — /dev appears only after READY
 lsmod | grep odl_tb5
+dmesg | grep 'odl_tb5: entering READY'
 ls /dev/odl_tb5_*
 
 # Install udev rule for persistent permissions
@@ -86,25 +103,34 @@ sudo udevadm control --reload-rules
 ## Install Verbs Provider Plugin
 
 ```bash
-sudo mkdir -p /usr/lib/aarch64-linux-gnu/libibverbs
-sudo cp build/verbs/libodl_tb5-rdmav34.so /usr/lib/aarch64-linux-gnu/libibverbs/
-ibv_devinfo
+# x86_64:
+sudo mkdir -p /usr/lib/x86_64-linux-gnu/libibverbs
+sudo cp build/verbs/libodl_tb5-rdmav34.so /usr/lib/x86_64-linux-gnu/libibverbs/
+
+# aarch64:
+# sudo mkdir -p /usr/lib/aarch64-linux-gnu/libibverbs
+# sudo cp build/verbs/libodl_tb5-rdmav34.so /usr/lib/aarch64-linux-gnu/libibverbs/
+
+# On OdinLink-only hosts the directory plugin may not load. Use:
+LD_PRELOAD=build/verbs/libodl_tb5_verbs.so ibv_devinfo
 ```
 
 ## Run Performance Tests
 
 Both machines must have the driver loaded and be connected via TB5 cable.
+Wait for `odl_tb5: entering READY state` in dmesg on both sides first
+(after a module reload there is a short DMA-ping window).
 
 ```bash
-# Machine A (server):
-./build/cli/odl_tb5_cli --server --device 0
+# Machine A (server) — positional mode, not --server:
+./build/cli/odl_tb5_cli server -d 0
 
 # Machine B (client):
-./build/cli/odl_tb5_cli --client --device 0 --test bandwidth
-./build/cli/odl_tb5_cli --client --device 0 --test latency
-./build/cli/odl_tb5_cli --client --device 0 --test jitter
-./build/cli/odl_tb5_cli --client --device 0 --test latency-load
-./build/cli/odl_tb5_cli --client --device 0 --test mimo
+./build/cli/odl_tb5_cli client -d 0 -t bandwidth -b 64K,1M,4M
+./build/cli/odl_tb5_cli client -d 0 -t latency
+./build/cli/odl_tb5_cli client -d 0 -t jitter
+./build/cli/odl_tb5_cli client -d 0 -t latency-load
+./build/cli/odl_tb5_cli client -d 0 -t mimo
 ```
 
 ## Start Daemon and Tray

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -5,9 +5,13 @@
 | Problem | Solution |
 |---------|----------|
 | Build fails with unknown GCC flags | GCC is too old. Install version matching kernel (`cat /proc/version`) |
-| Module won't load | Check `dmesg | grep odl_tb5`. Ensure TB5 hardware is present (`lspci | grep Thunderbolt`) |
-| No `/dev/odl_tb5_*` devices | Device appears only when a TB5 peer connects. Check `dmesg` for XDomain events. Use `loopback=1` for no-cable testing |
+| Module won't load | Check `dmesg \| grep odl_tb5`. Ensure TB5 hardware is present (`lspci \| grep Thunderbolt`) |
+| No `/dev/odl_tb5_*` devices | Device appears only when a TB5 peer connects and the link reaches **READY**. After plug or reload wait for `odl_tb5: entering READY state` (DMA-ping can take ~tens of seconds). Use `loopback=1` for no-cable testing |
 | Permission denied | Install udev rule or `sudo chmod 660 /dev/odl_tb5_*` |
+| Probe fails with `failed to alloc TX DMA buf` / `-12` | Identity IOMMU (`iommu=pt`). Load with `odl_ring_size=1024`, or use a translated IOMMU domain. Recent drivers auto-downgrade ring size |
+| `insmod ... ring_size=1024` ignored | Parameter is named **`odl_ring_size`**, not `ring_size` |
+| Link looks READY but every app handshake times out | Protocol version mismatch between nodes. dmesg should now show `peer protocol version N != local M — refusing`. Update both sides to the same revision |
+| CLI server: `Receive error: Protocol error` after 1–2 tests | Multi-block-size bandwidth needs one TEST_REQ per size (fixed in recent CLI). Update both client and server binaries |
 
 ## Daemon & Tray
 
@@ -20,9 +24,17 @@
 
 | Problem | Solution |
 |---------|----------|
-| `ibv_devinfo` doesn't show ODL device | Provider plugin not installed. Check `/usr/lib/*/libibverbs/` for `libodl_tb5-rdmav34.so` |
-| `ibv_open_device` fails | Check `ODL_VERBS_DEBUG=5` for details. Ensure module loaded |
+| `ibv_devinfo` shows no devices | On OdinLink-only hosts the directory plugin never loads (rdma-core only dlopens providers for sysfs RDMA devices). Use `LD_PRELOAD=.../libodl_tb5_verbs.so ibv_devinfo` |
+| `ibv_open_device` fails | Check `ODL_VERBS_DEBUG=5` for details. Ensure module loaded and peer READY |
 | `ibv_post_send` returns `-EAGAIN` | Normal for non-blocking mode. Worker thread retries after poll |
+
+## RCCL / NCCL
+
+| Problem | Solution |
+|---------|----------|
+| Collectives work but are ~4× too slow | Silent Socket fallback. Check logs for `Using network Socket` vs `Using network ODL_TB5`. Put `librccl-net.so` on `LD_LIBRARY_PATH` / `RCCL_PLUGIN_DIR` |
+| `NET/IB : No device found` with RCCL | Expected without the net plugin — RCCL bypasses `LD_PRELOAD` verbs. Use `rccl_net_odl_tb5` / `librccl-net.so` |
+| Built artifact name vs probe name | Build produces `librccl_net_odl_tb5.so`; RCCL probes `librccl-net.so`. CMake creates a symlink in the build tree and installs both names |
 
 ## GRUB
 

--- a/driver/odl_tb5_proto.c
+++ b/driver/odl_tb5_proto.c
@@ -111,7 +111,7 @@ static int odl_tb5_proto_handle_packet(const void *buf, size_t size,
 
 	if (!dev) {
 		mutex_unlock(&odl_tb5_devices_lock);
-		pr_warn("OdinLink: incoming packet route %llx — no matching device\n",
+		pr_warn("odl_tb5: incoming packet route %llx — no matching device\n",
 			route);
 		return 0;
 	}
@@ -143,7 +143,7 @@ static int odl_tb5_proto_handle_packet(const void *buf, size_t size,
 			proto_ver = payload[0];
 		}
 
-		pr_info("OdinLink: received login from peer "
+		pr_info("odl_tb5: received login from peer "
 			"(version=%u, tx_path=%u, size=%zu)\n",
 			proto_ver, remote_tx_hopid, size);
 
@@ -154,12 +154,32 @@ static int odl_tb5_proto_handle_packet(const void *buf, size_t size,
 			(sizeof(resp) / 4 - XD_HDR_SIZE_DW);
 		resp.xd_hdr.uuid      = odl_tb5_proto_uuid;
 		resp.xd_hdr.type      = ODL_TB5_MSG_LOGIN_RSP;
-		resp.status            = 0;
+		resp.status            = ODL_TB5_LOGIN_STATUS_OK;
 		resp.transmit_path     = dev->local_tx_hopid;
+
+		/*
+		 * Full OdinLink login packets carry proto_version and must
+		 * match. Short / Apple-style packets omit a meaningful
+		 * version (often 0) — skip the check for those and when
+		 * protocol=1 (macOS compat).
+		 */
+		if (odl_protocol_mode == 0 &&
+		    size >= sizeof(*pkg) &&
+		    proto_ver != ODL_TB5_PROTOCOL_VER) {
+			pr_err("odl_tb5: peer protocol version %u != local %u "
+			       "— refusing (update both nodes to the same "
+			       "driver revision)\n",
+			       proto_ver, ODL_TB5_PROTOCOL_VER);
+			resp.status = ODL_TB5_LOGIN_STATUS_PROTO_MISMATCH;
+			ret = tb_xdomain_response(dev->xd, &resp, sizeof(resp),
+						  TB_CFG_PKG_XDOMAIN_RESP);
+			mutex_unlock(&odl_tb5_devices_lock);
+			return 1;
+		}
 
 		ret = tb_xdomain_response(dev->xd, &resp, sizeof(resp),
 					  TB_CFG_PKG_XDOMAIN_RESP);
-		pr_info("OdinLink: sent login response (ret=%d, route=%llx, "
+		pr_info("odl_tb5: sent login response (ret=%d, route=%llx, "
 			"sn=%u, tx_hopid=%d)\n",
 			ret, dev->xd->route,
 			(hdr->length_sn & XD_SN_MASK) >> 27,
@@ -167,7 +187,7 @@ static int odl_tb5_proto_handle_packet(const void *buf, size_t size,
 
 		mutex_lock(&dev->state_lock);
 		if (dev->state != ODL_TB5_STATE_HANDSHAKE) {
-			pr_info("OdinLink: peer restarted (our state=%d), "
+			pr_info("odl_tb5: peer restarted (our state=%d), "
 				"scheduling restart\n", dev->state);
 			dev->stale_remote_tx_hopid = dev->remote_tx_hopid;
 			dev->remote_tx_hopid = remote_tx_hopid;
@@ -192,7 +212,7 @@ static int odl_tb5_proto_handle_packet(const void *buf, size_t size,
 	}
 
 	case ODL_TB5_MSG_LOGOUT:
-		pr_info("OdinLink: received logout from peer\n");
+		pr_info("odl_tb5: received logout from peer\n");
 
 		mutex_lock(&dev->state_lock);
 		dev->stale_remote_tx_hopid = dev->remote_tx_hopid;
@@ -245,7 +265,7 @@ int odl_tb5_proto_send_login(struct odl_tb5_device *dev)
 				 TB_CFG_PKG_XDOMAIN_RESP,
 				 ODL_TB5_LOGIN_TIMEOUT);
 	if (ret) {
-		pr_warn("OdinLink: login request failed: %d\n", ret);
+		pr_warn("odl_tb5: login request failed: %d\n", ret);
 		return ret;
 	}
 
@@ -260,19 +280,25 @@ int odl_tb5_proto_send_login(struct odl_tb5_device *dev)
 	}
 
 	if (!uuid_equal(&resp.xd_hdr.uuid, &odl_tb5_proto_uuid)) {
-		pr_warn("OdinLink: login response UUID mismatch\n");
+		pr_warn("odl_tb5: login response UUID mismatch\n");
 		return -EPROTO;
 	}
 
 	if (resp.xd_hdr.type != ODL_TB5_MSG_LOGIN_RSP) {
-		pr_warn("OdinLink: unexpected response type %u\n",
+		pr_warn("odl_tb5: unexpected response type %u\n",
 			resp.xd_hdr.type);
 		return -EPROTO;
 	}
 
-	if (resp.status != 0) {
-		pr_warn("OdinLink: peer rejected login with status %u\n",
-			resp.status);
+	if (resp.status != ODL_TB5_LOGIN_STATUS_OK) {
+		if (resp.status == ODL_TB5_LOGIN_STATUS_PROTO_MISMATCH)
+			pr_err("odl_tb5: peer rejected login — protocol "
+			       "version mismatch (local=%u). Update both "
+			       "nodes to the same driver revision.\n",
+			       ODL_TB5_PROTOCOL_VER);
+		else
+			pr_err("odl_tb5: peer rejected login (status=%u)\n",
+			       resp.status);
 		return -ECONNREFUSED;
 	}
 
@@ -283,7 +309,7 @@ login_ok:
 		need_complete = true;
 	mutex_unlock(&dev->state_lock);
 
-	pr_info("OdinLink: login sent OK, remote_tx_hopid=%d\n",
+	pr_info("odl_tb5: login sent OK, remote_tx_hopid=%d\n",
 		dev->remote_tx_hopid);
 
 	if (need_complete)
@@ -313,14 +339,14 @@ static int odl_tb5_complete_connection(struct odl_tb5_device *dev)
 
 	ret = tb_xdomain_alloc_in_hopid(dev->xd, dev->remote_tx_hopid);
 	if (ret < 0) {
-		pr_err("OdinLink: failed to allocate input HopID: %d\n", ret);
+		pr_err("odl_tb5: failed to allocate input HopID: %d\n", ret);
 		return ret;
 	}
 	dev->in_hopid = dev->remote_tx_hopid;
 	dev->in_hopid_valid = true;
 	ret = odl_tb5_rings_start(dev);
 	if (ret) {
-		pr_err("OdinLink: failed to start rings: %d\n", ret);
+		pr_err("odl_tb5: failed to start rings: %d\n", ret);
 		tb_xdomain_release_in_hopid(dev->xd, dev->in_hopid);
 		dev->in_hopid_valid = false;
 		return ret;
@@ -331,13 +357,13 @@ static int odl_tb5_complete_connection(struct odl_tb5_device *dev)
 
 		ret = odl_tb5_submit_rx(dev, 0, rx_prime);
 		if (ret) {
-			pr_err("OdinLink: failed to prime RX: %d\n", ret);
+			pr_err("odl_tb5: failed to prime RX: %d\n", ret);
 			odl_tb5_rings_stop(dev);
 			tb_xdomain_release_in_hopid(dev->xd, dev->in_hopid);
 			dev->in_hopid_valid = false;
 			return ret;
 		}
-		pr_info("OdinLink: RX primed with 16 frames before "
+		pr_info("odl_tb5: RX primed with 16 frames before "
 			"enable_paths\n");
 	}
 
@@ -351,7 +377,7 @@ static int odl_tb5_complete_connection(struct odl_tb5_device *dev)
 			break;
 
 		if (i < ODL_TB5_ENABLE_RETRIES - 1) {
-			pr_warn("OdinLink: enable_paths failed (%d), "
+			pr_warn("odl_tb5: enable_paths failed (%d), "
 				"retry %d/%d in %d ms\n",
 				ret, i + 1, ODL_TB5_ENABLE_RETRIES,
 				ODL_TB5_ENABLE_DELAY);
@@ -360,7 +386,7 @@ static int odl_tb5_complete_connection(struct odl_tb5_device *dev)
 	}
 
 	if (ret) {
-		pr_err("OdinLink: failed to enable XDomain paths "
+		pr_err("odl_tb5: failed to enable XDomain paths "
 		       "after %d attempts: %d\n",
 		       ODL_TB5_ENABLE_RETRIES, ret);
 		odl_tb5_rings_stop(dev);
@@ -374,7 +400,7 @@ static int odl_tb5_complete_connection(struct odl_tb5_device *dev)
 	wake_up_all(&dev->state_waitq);
 	mutex_unlock(&dev->state_lock);
 
-	pr_info("OdinLink: connected to peer "
+	pr_info("odl_tb5: connected to peer "
 		"(local_tx_hopid=%d, remote_tx_hopid=%d, "
 		"tx_ring_hop=%d, rx_ring_hop=%d, "
 		"ring_size=%d, E2E enabled)\n",
@@ -390,7 +416,7 @@ static int odl_tb5_complete_connection(struct odl_tb5_device *dev)
 		int pool_ret = odl_tb5_frame_pool_alloc(dev);
 
 		if (pool_ret)
-			pr_warn("OdinLink: frame pool alloc failed (%d), "
+			pr_warn("odl_tb5: frame pool alloc failed (%d), "
 				"verify will use legacy path\n", pool_ret);
 	}
 
@@ -399,7 +425,7 @@ static int odl_tb5_complete_connection(struct odl_tb5_device *dev)
 		int bret = odl_tb5_batch_pool_alloc(dev);
 
 		if (bret)
-			pr_warn("OdinLink: batch pool alloc failed (%d), "
+			pr_warn("odl_tb5: batch pool alloc failed (%d), "
 				"throughput mode disabled\n", bret);
 	}
 
@@ -425,7 +451,7 @@ static void odl_tb5_connect_work_fn(struct work_struct *work)
 		dev->login_received = false;
 		mutex_unlock(&dev->state_lock);
 
-		pr_warn("OdinLink: connection completion failed (%d), "
+		pr_warn("odl_tb5: connection completion failed (%d), "
 			"retrying handshake\n", ret);
 		schedule_delayed_work(&dev->login_work,
 				      msecs_to_jiffies(1000));
@@ -491,7 +517,7 @@ static void odl_tb5_ctrl_reply_work_fn(struct work_struct *work)
 	if (type == ODL_TB5_DMA_PING) {
 		int ret;
 
-		pr_info("OdinLink: DMA ping received, sending pong\n");
+		pr_info("odl_tb5: DMA ping received, sending pong\n");
 		ret = odl_tb5_send_dma_msg(dev, ODL_TB5_DMA_PONG);
 
 		/* BUG 10 fix: answering a PING is itself proof the DMA path
@@ -510,7 +536,7 @@ static void odl_tb5_ctrl_reply_work_fn(struct work_struct *work)
 			wake_up_all(&dev->verify_waitq);
 		}
 	} else {
-		pr_warn("OdinLink: unexpected DMA ctrl message type %d\n",
+		pr_warn("odl_tb5: unexpected DMA ctrl message type %d\n",
 			type);
 	}
 }
@@ -539,14 +565,14 @@ static void odl_tb5_verify_work_fn(struct work_struct *work)
 	if (dev->frame_pool.slots) {
 		dev->rx_target = dev->frame_pool.size / 2;
 		odl_tb5_rx_repost(dev);
-		pr_info("OdinLink: verify using pool RX (target=%d)\n",
+		pr_info("odl_tb5: verify using pool RX (target=%d)\n",
 			dev->rx_target);
 	} else {
 		size_t buf_size = (size_t)ODL_TB5_FRAME_SIZE * 16;
 
 		ret = odl_tb5_submit_rx(dev, 0, buf_size);
 		if (ret) {
-			pr_warn("OdinLink: DMA verify: failed to post RX "
+			pr_warn("odl_tb5: DMA verify: failed to post RX "
 				"(%ld)\n", ret);
 			goto out_reset;
 		}
@@ -564,13 +590,13 @@ static void odl_tb5_verify_work_fn(struct work_struct *work)
 
 		ret = odl_tb5_send_dma_msg(dev, ODL_TB5_DMA_PING);
 		if (ret) {
-			pr_warn("OdinLink: DMA verify: send ping failed "
+			pr_warn("odl_tb5: DMA verify: send ping failed "
 				"(%ld)\n", ret);
 			goto out_reset;
 		}
 
 		if (attempt == 0)
-			pr_info("OdinLink: DMA ping sent, "
+			pr_info("odl_tb5: DMA ping sent, "
 				"waiting for pong\n");
 
 		ret = wait_event_interruptible_timeout(
@@ -584,7 +610,7 @@ static void odl_tb5_verify_work_fn(struct work_struct *work)
 			goto out_reset;
 
 		if ((attempt + 1) % 50 == 0)
-			pr_info("OdinLink: DMA ping attempt %d, "
+			pr_info("odl_tb5: DMA ping attempt %d, "
 				"still waiting for pong\n", attempt + 1);
 
 		/* Do NOT reset the RX ring here — that kills in-flight
@@ -592,12 +618,12 @@ static void odl_tb5_verify_work_fn(struct work_struct *work)
 	}
 
 	if (!dev->pong_received && !dev->peer_ping_answered) {
-		pr_err("OdinLink: DMA verify failed after %d attempts\n",
+		pr_err("odl_tb5: DMA verify failed after %d attempts\n",
 		       attempt);
 		goto out_reset;
 	}
 
-	pr_info("OdinLink: DMA path verified, resetting rings for userspace\n");
+	pr_info("odl_tb5: DMA path verified, resetting rings for userspace\n");
 
 	flush_work(&dev->ctrl_reply_work);
 	hrtimer_cancel(&dev->rx_poll_timer);
@@ -623,7 +649,7 @@ static void odl_tb5_verify_work_fn(struct work_struct *work)
 		      ns_to_ktime(ODL_TB5_POLL_INTERVAL_NS),
 		      HRTIMER_MODE_REL);
 
-	pr_info("OdinLink: entering READY state\n");
+	pr_info("odl_tb5: entering READY state\n");
 	return;
 
 out_reset:
@@ -664,7 +690,7 @@ static void odl_tb5_restart_work_fn(struct work_struct *work)
 	dev->login_retries = 0;
 	mutex_unlock(&dev->state_lock);
 
-	pr_info("OdinLink: connection restarted, beginning handshake\n");
+	pr_info("odl_tb5: connection restarted, beginning handshake\n");
 	schedule_delayed_work(&dev->login_work, 0);
 }
 
@@ -687,7 +713,7 @@ static void odl_tb5_login_work_fn(struct work_struct *work)
 
 		if (dev->login_retries <= 5 ||
 		    dev->login_retries % 10 == 0)
-			pr_info("OdinLink: login attempt %d failed (%d), "
+			pr_info("odl_tb5: login attempt %d failed (%d), "
 				"retrying in %lu ms\n",
 				dev->login_retries, ret, delay_ms);
 
@@ -699,7 +725,7 @@ static void odl_tb5_login_work_fn(struct work_struct *work)
 		 * Give up and stay quiescent instead. */
 		if (odl_login_max_retries > 0 &&
 		    dev->login_retries >= odl_login_max_retries) {
-			pr_warn("OdinLink: giving up after %d login attempts "
+			pr_warn("odl_tb5: giving up after %d login attempts "
 				"(last err %d); staying idle.  Check the peer "
 				"is up and only ONE service is bound.\n",
 				dev->login_retries, ret);
@@ -731,7 +757,7 @@ int odl_tb5_proto_send_logout(struct odl_tb5_device *dev)
 	wake_up_all(&dev->state_waitq);
 	mutex_unlock(&dev->state_lock);
 
-	pr_info("OdinLink: logout sent to peer\n");
+	pr_info("odl_tb5: logout sent to peer\n");
 
 	return 0;
 }

--- a/driver/odl_tb5_ring_dma.c
+++ b/driver/odl_tb5_ring_dma.c
@@ -276,7 +276,7 @@ void odl_tb5_rx_callback(struct tb_ring *ring,
 					u32 type = le32_to_cpu(dhdr->type);
 
 					if (type == ODL_TB5_DMA_PONG) {
-						pr_info("OdinLink: DMA pong received (pool)\n");
+						pr_info("odl_tb5: DMA pong received (pool)\n");
 						dev->pong_received = true;
 						wake_up_interruptible(&dev->verify_waitq);
 					} else {
@@ -487,7 +487,7 @@ rx_frame_done:
 			u32 type = le32_to_cpu(hdr->type);
 
 			if (type == ODL_TB5_DMA_PONG) {
-				pr_info("OdinLink: DMA pong received\n");
+				pr_info("odl_tb5: DMA pong received\n");
 				dev->pong_received = true;
 				wake_up_interruptible(&dev->verify_waitq);
 			} else {
@@ -518,7 +518,7 @@ int odl_tb5_rings_alloc(struct odl_tb5_device *dev)
 	dev->tx.ring_size = rs;
 	dev->rx.ring_size = rs;
 
-	pr_info("odl_tb5: ring_size=%u (%u MB per batch, %u MB total)\n",
+	pr_info("odl_tb5: odl_ring_size=%u (%u MB per batch, %u MB total)\n",
 		rs,
 		(rs * ODL_TB5_FRAME_SIZE) >> 20,
 		(rs * ODL_TB5_FRAME_SIZE * ODL_TB5_NUM_BUFFERS * 2) >> 20);

--- a/driver/odl_tb5_service.c
+++ b/driver/odl_tb5_service.c
@@ -154,18 +154,70 @@ static int odl_tb5_probe(struct tb_service *svc,
 		goto err_free_dev;
 	}
 
-	ret = odl_tb5_rings_alloc(dev);
-	if (ret) {
-		pr_err("odl_tb5: ring alloc failed for index %d: %d\n",
-		       dev->index, ret);
-		goto err_chardev;
-	}
+	/*
+	 * On identity-IOMMU hosts (common with iommu=pt on Proxmox/virt),
+	 * dma_alloc_coherent needs physically contiguous memory. The default
+	 * odl_ring_size=4096 requests 16 MB batches (order-12) and fails with
+	 * -ENOMEM even when RAM is free. Retry with progressively smaller
+	 * power-of-two ring sizes so probe still succeeds (issue #23).
+	 */
+	{
+		unsigned int try_rs = odl_ring_size;
+		unsigned int requested = odl_ring_size;
+		int last_err = -ENOMEM;
 
-	ret = odl_tb5_dma_bufs_alloc(dev);
-	if (ret) {
-		pr_err("odl_tb5: DMA buf alloc failed for index %d: %d\n",
-		       dev->index, ret);
-		goto err_rings;
+		while (try_rs >= ODL_TB5_RING_SIZE_MIN) {
+			odl_ring_size = try_rs;
+			ret = odl_tb5_rings_alloc(dev);
+			if (ret) {
+				last_err = ret;
+				pr_err("odl_tb5: ring alloc failed for index %d "
+				       "(odl_ring_size=%u): %d\n",
+				       dev->index, try_rs, ret);
+				try_rs >>= 1;
+				continue;
+			}
+
+			ret = odl_tb5_dma_bufs_alloc(dev);
+			if (!ret) {
+				if (try_rs != requested)
+					pr_warn("odl_tb5: reduced odl_ring_size "
+						"%u → %u after alloc failure "
+						"(identity IOMMU / iommu=pt often "
+						"needs odl_ring_size=1024)\n",
+						requested, try_rs);
+				/* Keep the working size for any later probes. */
+				odl_ring_size = try_rs;
+				dev->tx_adaptive.high_watermark =
+					min_t(unsigned int, try_rs * 3 / 4,
+					      ODL_TB5_FRAME_POOL_SIZE -
+					      ODL_TB5_TX_POOL_RESERVE);
+				dev->tx_adaptive.low_watermark =
+					min_t(unsigned int, try_rs / 4,
+					      (ODL_TB5_FRAME_POOL_SIZE -
+					       ODL_TB5_TX_POOL_RESERVE) / 2);
+				break;
+			}
+
+			last_err = ret;
+			pr_err("odl_tb5: DMA buf alloc failed for index %d "
+			       "(odl_ring_size=%u, %zu bytes/batch): %d\n",
+			       dev->index, try_rs,
+			       (size_t)ODL_TB5_FRAME_SIZE * try_rs, ret);
+			odl_tb5_rings_free(dev);
+			try_rs >>= 1;
+		}
+
+		if (ret) {
+			odl_ring_size = requested;
+			pr_err("odl_tb5: could not allocate DMA rings/buffers "
+			       "down to odl_ring_size=%u (last err %d). On "
+			       "iommu=pt hosts try: modprobe odl_tb5 "
+			       "odl_ring_size=1024\n",
+			       ODL_TB5_RING_SIZE_MIN, last_err);
+			ret = last_err;
+			goto err_chardev;
+		}
 	}
 
 	ret = odl_tb5_proto_init(dev);
@@ -300,7 +352,7 @@ static int __init odl_tb5_init(void)
 	if (!is_power_of_2(odl_ring_size) ||
 	    odl_ring_size < ODL_TB5_RING_SIZE_MIN ||
 	    odl_ring_size > ODL_TB5_RING_SIZE_MAX) {
-		pr_err("odl_tb5: invalid ring_size=%u (must be power-of-2, %u-%u)\n",
+		pr_err("odl_tb5: invalid odl_ring_size=%u (must be power-of-2, %u-%u)\n",
 		       odl_ring_size, ODL_TB5_RING_SIZE_MIN,
 		       ODL_TB5_RING_SIZE_MAX);
 		return -EINVAL;
@@ -390,7 +442,7 @@ static int __init odl_tb5_init(void)
 	if (ret)
 		goto err_proto;
 
-	pr_info("odl_tb5: OdinLink TB5 driver loaded (ring_size=%u)\n",
+	pr_info("odl_tb5: OdinLink TB5 driver loaded (odl_ring_size=%u)\n",
 		odl_ring_size);
 
 	return 0;

--- a/driver/uapi/odl_tb5_uapi.h
+++ b/driver/uapi/odl_tb5_uapi.h
@@ -45,7 +45,15 @@ typedef int64_t  __s64;
 
 #define ODL_TB5_PROTOCOL_KEY   "odinlink"
 #define ODL_TB5_PROTOCOL_ID    0x4F4C
-#define ODL_TB5_PROTOCOL_VER   1
+/* Bumped when the on-wire stream format changes. Login refuses peers that
+ * advertise a different version so mismatched revs fail loudly instead of
+ * looking healthy and timing out every application handshake (issue #23).
+ *   1 — original 5-byte stream header
+ *   2 — 8-byte stream header with frag_idx (commit 14422e6) */
+#define ODL_TB5_PROTOCOL_VER   2
+/* Non-zero status values in the XDomain login response. */
+#define ODL_TB5_LOGIN_STATUS_OK             0
+#define ODL_TB5_LOGIN_STATUS_PROTO_MISMATCH 1
 
 /* Apple ThunderboltRDMA protocol — for cross-platform Mac ↔ Linux interop
  * Source: AppleThunderboltRDMA.kext Info.plist IOPropertyMatch Protocol ID

--- a/packaging/dkms-install.sh
+++ b/packaging/dkms-install.sh
@@ -34,12 +34,12 @@ cp driver/Kbuild                "$SRC_DIR/"
 cp driver/Makefile              "$SRC_DIR/"
 cp driver/uapi/odl_tb5_uapi.h   "$SRC_DIR/uapi/"
 
-# Configure dkms.conf with the version
+# Substitute @PROJECT_VERSION@ into dkms.conf and the postinst/prerm helpers.
+# (Copying the helpers verbatim left the placeholder literal and made DKMS
+# look for /usr/src/odl-tb5-@PROJECT_VERSION@ — issue #23.)
 sed "s/@PROJECT_VERSION@/$PACKAGE_VERSION/g" packaging/dkms.conf > "$SRC_DIR/dkms.conf"
-
-# Copy helper scripts
-cp packaging/dkms-postinst.sh    "$SRC_DIR/"
-cp packaging/dkms-prerm.sh      "$SRC_DIR/"
+sed "s/@PROJECT_VERSION@/$PACKAGE_VERSION/g" packaging/dkms-postinst.sh > "$SRC_DIR/dkms-postinst.sh"
+sed "s/@PROJECT_VERSION@/$PACKAGE_VERSION/g" packaging/dkms-prerm.sh > "$SRC_DIR/dkms-prerm.sh"
 chmod +x "$SRC_DIR/dkms-postinst.sh" "$SRC_DIR/dkms-prerm.sh"
 
 # Register with DKMS

--- a/rccl/CMakeLists.txt
+++ b/rccl/CMakeLists.txt
@@ -13,3 +13,17 @@ install(TARGETS rccl_net_odl_tb5
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT rccl
 )
+# RCCL probes librccl-net.so (exact name) via LD_LIBRARY_PATH / plugin dir.
+# Install a second name so users do not need a manual symlink (issue #23).
+install(FILES $<TARGET_FILE:rccl_net_odl_tb5>
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RENAME librccl-net.so
+    COMPONENT rccl
+)
+# Convenience copy next to the build tree artifact for local (non-install) runs.
+add_custom_command(TARGET rccl_net_odl_tb5 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+        $<TARGET_FILE_NAME:rccl_net_odl_tb5>
+        $<TARGET_FILE_DIR:rccl_net_odl_tb5>/librccl-net.so
+    COMMENT "Symlink librccl-net.so → librccl_net_odl_tb5.so for RCCL probe"
+)

--- a/rccl/src/odl_tb5_plugin.c
+++ b/rccl/src/odl_tb5_plugin.c
@@ -237,9 +237,25 @@ static void put_shared_handle(void)
 
 static rcclResult_t odl_tb5_init(rcclDebugLogger_t logFunction)
 {
+	const char *preload;
+
 	odl_logger = logFunction;
 	odl_dbg_init();
 	DBG(1, "init: plugin loaded pid=%d", (int)getpid());
+	/* One-line confirmation so logs prove the fast path is active
+	 * (silent Socket fallback is the #1 footgun — issue #23). */
+	if (odl_logger)
+		odl_logger(3 /* INFO */,
+			   "ODL_TB5 net plugin loaded (use NET/ODL_TB5, not Socket)");
+	else
+		fprintf(stderr, "NCCL INFO ODL_TB5 net plugin loaded\n");
+
+	preload = getenv("LD_PRELOAD");
+	if (preload && strstr(preload, "odl_tb5_verbs"))
+		WARN("LD_PRELOAD includes odl_tb5_verbs — that interposer does "
+		     "not help RCCL (it dlopens libibverbs.so.1 directly). "
+		     "This net plugin is the supported path.");
+
 	stats_init();
 	atexit(stats_cleanup);
 	return rcclSuccess;

--- a/verbs/CMakeLists.txt
+++ b/verbs/CMakeLists.txt
@@ -76,14 +76,23 @@ install(TARGETS odl_tb5_verbs
 option(ODL_VERBS_BUILD_PROVIDER_PLUGIN "Build rdma-core provider plugin" ON)
 
 if(ODL_VERBS_BUILD_PROVIDER_PLUGIN)
-    # Determine provider plugin install directory
+    # Prefer the multiarch libibverbs dir matching the host, not a hard-coded
+    # aarch64 path that wins on multiarch x86 boxes (issue #23).
     unset(IBVERBS_PROVIDER_DIR)
-    foreach(DIR
-        "/usr/lib/aarch64-linux-gnu/libibverbs"
-        "/usr/lib/x86_64-linux-gnu/libibverbs"
-        "/usr/lib64/libibverbs"
-        "/usr/lib/libibverbs"
-        "${CMAKE_INSTALL_LIBDIR}/libibverbs")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+        set(_ODL_IBV_CANDIDATES
+            "/usr/lib/aarch64-linux-gnu/libibverbs"
+            "/usr/lib64/libibverbs"
+            "/usr/lib/libibverbs"
+            "${CMAKE_INSTALL_LIBDIR}/libibverbs")
+    else()
+        set(_ODL_IBV_CANDIDATES
+            "/usr/lib/x86_64-linux-gnu/libibverbs"
+            "/usr/lib64/libibverbs"
+            "/usr/lib/libibverbs"
+            "${CMAKE_INSTALL_LIBDIR}/libibverbs")
+    endif()
+    foreach(DIR ${_ODL_IBV_CANDIDATES})
         if(IS_DIRECTORY "${DIR}")
             set(IBVERBS_PROVIDER_DIR "${DIR}")
             break()


### PR DESCRIPTION
## Summary

Addresses the field report from two-node AMD Strix Halo + Proxmox deployment in #23. OdinLink works well once configured; most of the pain was silent Socket fallback for RCCL, opaque protocol mismatches, and a few install/docs footguns.

### Fixes

| # | Issue | Change |
|---|-------|--------|
| 1 | RCCL/NCCL silent Socket fallback | Docs rewrite: net plugin is the supported path. Build installs/symlinks `librccl-net.so`. Plugin logs on load and warns if verbs `LD_PRELOAD` is present. |
| 2 | rdma-core provider inert alone | Documented (sysfs RDMA device required). Full in-kernel IB class device left as future work. |
| 3 | CLI `Protocol error` after ~2 tests | One `TEST_REQ` per bandwidth block size (client + daemon). Accept `/` in `-b 64K/1M/4M`. |
| 4 | DKMS `@PROJECT_VERSION@` unsubstituted | `dkms-install.sh` sed's postinst/prerm. |
| 5 | Userspace/container builds hard-fail | Missing kernel headers → `BUILD_KERNEL_MODULE=OFF`. Distro-agnostic dep messages. |
| 6 | Protocol version silent fail | Bump `ODL_TB5_PROTOCOL_VER` **1 → 2**; refuse login on mismatch with a clear dmesg line. |
| 7 | `iommu=pt` DMA `-ENOMEM` | Probe auto-downgrades `odl_ring_size` on alloc failure; docs for identity IOMMU. |
| nits | Log prefix, param name, CLI flags, install arch | Unified `odl_tb5:` logs; `odl_ring_size=` in dmesg/docs; positional `server`/`client`; host multiarch verbs path. |

### Rollout note

**Both nodes must upgrade together** after this lands (`PROTOCOL_VER=2`). A v1 peer will fail login with an explicit error instead of looking READY and timing out every app handshake.

### Not in this PR

- amdgpu ISP oops on vfio unbind (not OdinLink)
- Kernel sysfs `infiniband` device so rdma-core discovers OdinLink without preload

## Test plan

- [x] Userspace build: `odl_tb5`, `odl_tb5_cli`, `rccl_net_odl_tb5` (+ `librccl-net.so` symlink)
- [ ] Two-node: multi-block bandwidth `client -t bandwidth -b 64K,1M,4M` without server Protocol error
- [ ] Mismatched revs refuse login with dmesg version message
- [ ] `iommu=pt` host: probe succeeds (possibly after auto-downgrade) or clear `odl_ring_size=1024` hint
- [ ] RCCL: logs show `Using network ODL_TB5` when `librccl-net.so` is on `LD_LIBRARY_PATH`
- [ ] DKMS install no longer references `@PROJECT_VERSION@` path

Thanks @eendeego for the excellent field report — happy to take further patches if anything still fails on Strix Halo hardware.

Closes #23