### PR TITLE
feat: Mac-readable ODLC LZ4 and measured compression on Test Overview

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
             libglib2.0-dev libgtk-3-dev \
             libayatana-appindicator3-dev \
             linux-headers-$(uname -r) gcc-14 \
-            python3-numpy
+            python3-numpy python3-lz4
       - name: Configure
         run: |
           mkdir build && cd build
@@ -35,12 +35,17 @@ jobs:
           make -j$(nproc) odl_tb5 odl_tb5_verbs odl_tb5_verbs_provider
           make -j$(nproc) odl_tb5_cli odl_tb5_daemon odl_tb5_tray
           make -j$(nproc) odl_tb5_test odl_tb5_test_rccl_dmabuf odl_tensor_send
+          make -j$(nproc) odl_compress odl_compress_host_test
       # The other suites need /dev/odl_tb5_N, which no runner has. This one
       # is pure userspace and was being built but never executed.
       - name: Run plugin test suite
         run: cd build && ./tests/odl_tb5_test plugin
       - name: Test RemoteStore + TB-bridge (localhost)
         run: python3 tests/test_odinlink_remote.py
+      - name: Test host LZ4 / ODLC (Mac-readable format)
+        run: |
+          ./build/compress/odl_compress_host_test
+          python3 compress/tests/test_odl_compress.py
       # A driver that does not compile must turn this job red. This step used
       # to be continue-on-error, which is how the module reached a PR branch
       # in a state where it had never once been built.
@@ -164,8 +169,13 @@ jobs:
           cmake .. -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_DAEMON=OFF -DBUILD_TRAY=OFF -DBUILD_VERBS=OFF
           make -j$(sysctl -n hw.ncpu) odl_tb5 odl_tb5_cli odl_tb5_test
+          make -j$(sysctl -n hw.ncpu) odl_compress odl_compress_host_test
       - name: Run plugin test suite
         run: cd build && ./tests/odl_tb5_test plugin
+      - name: Test host LZ4 / ODLC
+        run: |
+          ./build/compress/odl_compress_host_test
+          python3 compress/tests/test_odl_compress.py
       - name: Compile RDMA client
         run: |
           clang -Wall -c mac/odl_rdma_client.c \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,7 @@ add_custom_target(driver
 # Userspace library (libodl_tb5.so)
 add_subdirectory(lib)
 
-# Optional nvCOMP compression (never hard-fails; stub if nvCOMP missing)
-# See compress/CMakeLists.txt and docs/GPU.md §Compression
+# Host LZ4 (ODLC). nvCOMP is not wired — see compress/CMakeLists.txt
 add_subdirectory(compress)
 
 # RCCL plugin (librccl_net_odl_tb5.so)

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -62,7 +62,8 @@ Request:
     u32  meta_len
     u8[] meta_json  (dtype, shape, kind: numpy|torch)
     u64  data_len
-    u8[] data       (raw tensor bytes)
+    u8[] data       (raw tensor bytes, or ODLC lz4_block if
+                    meta.odlc is true / data starts with ODLC magic)
 
 Response:
   u8   status       0=OK, 1=NOT_FOUND, 2=BAD_OP, 3=OOM, 4=PROTOCOL
@@ -100,13 +101,13 @@ an extension of the training host's spill pool.
 
 ## What's missing
 
-- **Compression**: bf16 + lz4 would help if you're often offloading
-  near-zero activations. Out of scope for v1.
 - **Encryption**: zero. Run it on a private link only.
 
-Connection reuse and the Mac-side MLX wrap are in:
-`TBBridgeClient` keeps one TCP socket; `bridge/mlx_helpers.py` turns a
+Connection reuse, ODLC LZ4, and the Mac-side MLX wrap are in:
+`TBBridgeClient` keeps one TCP socket; tensors ≥ 256 KiB are ODLC
+lz4_block (`ODL_COMPRESS=0` to disable); `bridge/mlx_helpers.py` turns a
 stored blob into `mlx.array` (`copy=False` when mlx allows it) or a
-NumPy view. `TensorStore.view(key)` is the server-side hook.
+NumPy view. `TensorStore.view(key)` decompresses then wraps.
 
 Local check (no cable): `python3 tests/test_odinlink_remote.py`
+and `python3 compress/tests/test_odl_compress.py`

--- a/bridge/benchmark.py
+++ b/bridge/benchmark.py
@@ -88,6 +88,24 @@ def main():
 
     cli = TBBridgeClient(args.host, args.port)
 
+    try:
+        from odl_compress import compress, looks_compressed
+    except ImportError:
+        from bridge.odl_compress import compress, looks_compressed
+    print("\nCompression (measured on this host, no cable):")
+    for name, arr in (
+        ("zeros", np.zeros(1 << 20, dtype=np.float32)),
+        ("randn", np.random.randn(1 << 20).astype(np.float32)),
+    ):
+        raw = arr.tobytes()
+        wire = compress(raw)
+        if wire and looks_compressed(wire):
+            ratio = len(raw) / len(wire)
+            print(f"  {name:8} {len(raw)/1e6:.1f} MB → {len(wire)/1e6:.2f} MB  "
+                  f"{ratio:.2f}x   1 GiB wire → {ratio:.2f} GiB payload")
+        else:
+            print(f"  {name:8} incompressible (sent raw)")
+
     print(f"\nLatency ({args.iters * 4} stat round-trips):")
     lat = bench_latency(cli, args.iters * 4)
     print(f"  median={lat['median_us']:.1f}µs  p99={lat['p99_us']:.1f}µs  min={lat['min_us']:.1f}µs")

--- a/bridge/mlx_helpers.py
+++ b/bridge/mlx_helpers.py
@@ -145,5 +145,9 @@ def wrap_store(store) -> dict:
         if entry is None:
             continue
         meta, data = entry
-        out[key] = wrap_blob(meta, data)
+        try:
+            from odl_compress import maybe_decompress
+        except ImportError:
+            from bridge.odl_compress import maybe_decompress
+        out[key] = wrap_blob(meta, maybe_decompress(data))
     return out

--- a/bridge/odl_compress.py
+++ b/bridge/odl_compress.py
@@ -1,0 +1,395 @@
+"""ODLC + portable LZ4-block codec (the Mac-readable format).
+
+Matches ``compress/include/odl_tb5/odl_compress.h`` algo 4:
+
+    [32-byte LE header][num_chunks × {raw,comp} u32][LZ4 raw blocks]
+
+nvCOMP GDeflate / batched-LZ4 / Snappy (algo 1/2/3) are rejected here.
+A Mac cannot decode those.
+
+Backends, first one that works:
+  1. ``lz4.block`` (pip / python3-lz4)
+  2. Apple ``libcompression`` (COMPRESSION_LZ4_RAW) — always on macOS
+  3. ``liblz4`` via ctypes
+  4. ``libodl_compress`` via ctypes (``odl_compress_host``)
+
+Env (same names as the C library):
+  ODL_COMPRESS=0          disable
+  ODL_COMPRESS_THRESHOLD  default 262144
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import struct
+import sys
+from typing import Optional
+
+MAGIC = 0x4F444C43
+VERSION = 1
+ALGO_GDEFLATE = 1
+ALGO_LZ4_NVCOMP = 2
+ALGO_SNAPPY = 3
+ALGO_LZ4_BLOCK = 4
+CHUNK = 65536
+HDR_FMT = "<IHHQQII"
+HDR_SIZE = struct.calcsize(HDR_FMT)
+CHUNK_FMT = "<II"
+CHUNK_SIZE = struct.calcsize(CHUNK_FMT)
+
+# Apple compression.h
+_COMPRESSION_LZ4_RAW = 0x101
+
+
+def _env_off() -> bool:
+    v = os.environ.get("ODL_COMPRESS")
+    if v is None or v == "":
+        return False
+    return v in ("0", "false", "False", "off", "OFF", "no", "NO")
+
+
+def threshold() -> int:
+    raw = os.environ.get("ODL_COMPRESS_THRESHOLD", "")
+    if raw.isdigit() and int(raw) > 0:
+        return int(raw)
+    return 262144
+
+
+def should_compress(n: int) -> bool:
+    if _env_off():
+        return False
+    return n >= threshold()
+
+
+def looks_compressed(buf: bytes) -> bool:
+    if len(buf) < HDR_SIZE:
+        return False
+    magic, ver, algo, orig, comp, nchunks, _res = struct.unpack(
+        HDR_FMT, buf[:HDR_SIZE]
+    )
+    return (
+        magic == MAGIC
+        and ver == VERSION
+        and orig > 0
+        and comp > 0
+        and nchunks > 0
+        and algo == ALGO_LZ4_BLOCK
+    )
+
+
+class _Backend:
+    name = "none"
+
+    def compress(self, src: bytes) -> bytes:
+        raise NotImplementedError
+
+    def decompress(self, src: bytes, dst_len: int) -> bytes:
+        raise NotImplementedError
+
+
+class _Lz4Block(_Backend):
+    name = "lz4.block"
+
+    def __init__(self, mod):
+        self._mod = mod
+
+    def compress(self, src: bytes) -> bytes:
+        return self._mod.compress(src, store_size=False)
+
+    def decompress(self, src: bytes, dst_len: int) -> bytes:
+        return self._mod.decompress(src, uncompressed_size=dst_len)
+
+
+class _CtypesLz4(_Backend):
+    name = "liblz4"
+
+    def __init__(self, lib):
+        self._lib = lib
+        lib.LZ4_compress_default.argtypes = [
+            ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int, ctypes.c_int
+        ]
+        lib.LZ4_compress_default.restype = ctypes.c_int
+        lib.LZ4_decompress_safe.argtypes = [
+            ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int, ctypes.c_int
+        ]
+        lib.LZ4_decompress_safe.restype = ctypes.c_int
+        lib.LZ4_compressBound.argtypes = [ctypes.c_int]
+        lib.LZ4_compressBound.restype = ctypes.c_int
+
+    def compress(self, src: bytes) -> bytes:
+        bound = self._lib.LZ4_compressBound(len(src))
+        dst = ctypes.create_string_buffer(bound)
+        n = self._lib.LZ4_compress_default(src, dst, len(src), bound)
+        if n <= 0:
+            raise RuntimeError("LZ4_compress_default failed")
+        return dst.raw[:n]
+
+    def decompress(self, src: bytes, dst_len: int) -> bytes:
+        dst = ctypes.create_string_buffer(dst_len)
+        n = self._lib.LZ4_decompress_safe(src, dst, len(src), dst_len)
+        if n != dst_len:
+            raise RuntimeError("LZ4_decompress_safe failed")
+        return dst.raw[:n]
+
+
+class _AppleCompression(_Backend):
+    name = "libcompression"
+
+    def __init__(self, lib):
+        self._lib = lib
+        lib.compression_encode_buffer.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.c_void_p, ctypes.c_int,
+        ]
+        lib.compression_encode_buffer.restype = ctypes.c_size_t
+        lib.compression_decode_buffer.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.c_void_p, ctypes.c_int,
+        ]
+        lib.compression_decode_buffer.restype = ctypes.c_size_t
+
+    def compress(self, src: bytes) -> bytes:
+        dst = ctypes.create_string_buffer(len(src) + (len(src) // 16) + 64)
+        n = self._lib.compression_encode_buffer(
+            dst, len(dst), src, len(src), None, _COMPRESSION_LZ4_RAW
+        )
+        if n == 0:
+            raise RuntimeError("compression_encode_buffer failed")
+        return dst.raw[:n]
+
+    def decompress(self, src: bytes, dst_len: int) -> bytes:
+        dst = ctypes.create_string_buffer(dst_len)
+        n = self._lib.compression_decode_buffer(
+            dst, dst_len, src, len(src), None, _COMPRESSION_LZ4_RAW
+        )
+        if n != dst_len:
+            raise RuntimeError("compression_decode_buffer failed")
+        return dst.raw[:n]
+
+
+_backend: Optional[_Backend] = None
+_backend_tried = False
+
+
+def _load_odl_so():
+    names = []
+    env = os.environ.get("ODL_COMPRESS_LIB")
+    if env:
+        names.append(env)
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    for rel in (
+        "build/compress/libodl_compress.so",
+        "build/libodl_compress.so",
+        "build/compress/libodl_compress.dylib",
+        "build/libodl_compress.dylib",
+    ):
+        names.append(os.path.join(here, rel))
+    for path in names:
+        if os.path.isfile(path):
+            try:
+                return ctypes.CDLL(path)
+            except OSError:
+                continue
+    return None
+
+
+class _OdlLib(_Backend):
+    """Whole-blob host API from libodl_compress — used as last encode path."""
+
+    name = "libodl_compress"
+
+    def __init__(self, lib):
+        self._lib = lib
+        lib.odl_compress_host.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_size_t),
+        ]
+        lib.odl_compress_host.restype = ctypes.c_int
+        lib.odl_decompress_host.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_size_t),
+        ]
+        lib.odl_decompress_host.restype = ctypes.c_int
+        lib.odl_compress_host_max_wire_bytes.argtypes = [ctypes.c_size_t]
+        lib.odl_compress_host_max_wire_bytes.restype = ctypes.c_size_t
+
+    def wrap_compress(self, src: bytes) -> Optional[bytes]:
+        cap = self._lib.odl_compress_host_max_wire_bytes(len(src))
+        dst = ctypes.create_string_buffer(cap)
+        out_n = ctypes.c_size_t()
+        rc = self._lib.odl_compress_host(src, len(src), dst, cap, ctypes.byref(out_n))
+        if rc != 0:
+            return None
+        return dst.raw[: out_n.value]
+
+    def wrap_decompress(self, wire: bytes) -> bytes:
+        magic, ver, algo, orig, comp, nchunks, _res = struct.unpack(
+            HDR_FMT, wire[:HDR_SIZE]
+        )
+        del magic, ver, algo, comp, nchunks
+        dst = ctypes.create_string_buffer(orig)
+        out_n = ctypes.c_size_t()
+        rc = self._lib.odl_decompress_host(
+            wire, len(wire), dst, orig, ctypes.byref(out_n)
+        )
+        if rc != 0:
+            raise RuntimeError("odl_decompress_host failed")
+        return dst.raw[: out_n.value]
+
+
+def _pick_backend() -> Optional[_Backend]:
+    global _backend, _backend_tried
+    if _backend_tried:
+        return _backend
+    _backend_tried = True
+
+    try:
+        import lz4.block as lb  # type: ignore
+        _backend = _Lz4Block(lb)
+        return _backend
+    except ImportError:
+        pass
+
+    if sys.platform == "darwin":
+        for path in ("/usr/lib/libcompression.dylib", "libcompression.dylib"):
+            try:
+                _backend = _AppleCompression(ctypes.CDLL(path))
+                return _backend
+            except OSError:
+                continue
+
+    for cand in (
+        ctypes.util.find_library("lz4"),
+        "liblz4.so.1",
+        "liblz4.so",
+        "liblz4.dylib",
+    ):
+        if not cand:
+            continue
+        try:
+            _backend = _CtypesLz4(ctypes.CDLL(cand))
+            return _backend
+        except OSError:
+            continue
+
+    return _backend
+
+
+def backend_name() -> str:
+    b = _pick_backend()
+    if b:
+        return b.name
+    so = _load_odl_so()
+    return "libodl_compress" if so else "none"
+
+
+def _header(orig: int, comp: int, nchunks: int) -> bytes:
+    return struct.pack(
+        HDR_FMT, MAGIC, VERSION, ALGO_LZ4_BLOCK, orig, comp, nchunks, 0
+    )
+
+
+def compress(data: bytes) -> Optional[bytes]:
+    """Return an ODLC blob smaller than ``data``, or None to keep raw."""
+    if not data:
+        return None
+    so = _load_odl_so()
+    if so is not None:
+        try:
+            wrapped = _OdlLib(so).wrap_compress(data)
+            if wrapped and len(wrapped) < len(data) and looks_compressed(wrapped):
+                return wrapped
+        except (OSError, RuntimeError):
+            pass
+
+    be = _pick_backend()
+    if be is None:
+        return None
+
+    n = len(data)
+    nchunks = (n + CHUNK - 1) // CHUNK
+    table = bytearray()
+    blocks = bytearray()
+    for i in range(nchunks):
+        chunk = data[i * CHUNK : (i + 1) * CHUNK]
+        try:
+            c = be.compress(chunk)
+        except (ValueError, RuntimeError):
+            return None
+        if not c:
+            return None
+        table += struct.pack(CHUNK_FMT, len(chunk), len(c))
+        blocks += c
+    payload = bytes(table) + bytes(blocks)
+    if HDR_SIZE + len(payload) >= n:
+        return None
+    return _header(n, len(payload), nchunks) + payload
+
+
+def decompress(wire: bytes) -> bytes:
+    """Expand an ODLC lz4_block blob. Raises on nvCOMP or corrupt input."""
+    if len(wire) < HDR_SIZE:
+        raise ValueError("truncated ODLC header")
+    magic, ver, algo, orig, comp, nchunks, _res = struct.unpack(
+        HDR_FMT, wire[:HDR_SIZE]
+    )
+    if magic != MAGIC or ver != VERSION:
+        raise ValueError("not ODLC")
+    if algo != ALGO_LZ4_BLOCK:
+        raise ValueError(
+            f"ODLC algo={algo} is nvCOMP-native; Mac/host cannot decode it "
+            "(use lz4_block)"
+        )
+    if orig == 0 or nchunks == 0:
+        raise ValueError("empty ODLC")
+    table_n = nchunks * CHUNK_SIZE
+    if HDR_SIZE + comp > len(wire) or comp < table_n:
+        raise ValueError("truncated ODLC payload")
+
+    so = _load_odl_so()
+    if so is not None:
+        try:
+            return _OdlLib(so).wrap_decompress(wire)
+        except (OSError, RuntimeError):
+            pass
+
+    be = _pick_backend()
+    if be is None:
+        raise RuntimeError(
+            "no LZ4 backend (install python3-lz4, or build libodl_compress)"
+        )
+
+    table = wire[HDR_SIZE : HDR_SIZE + table_n]
+    blocks = wire[HDR_SIZE + table_n : HDR_SIZE + comp]
+    out = bytearray()
+    boff = 0
+    for i in range(nchunks):
+        raw, csz = struct.unpack_from(CHUNK_FMT, table, i * CHUNK_SIZE)
+        piece = blocks[boff : boff + csz]
+        if len(piece) != csz:
+            raise ValueError("truncated LZ4 block")
+        out += be.decompress(piece, raw)
+        boff += csz
+    if len(out) != orig:
+        raise ValueError("decompressed size mismatch")
+    return bytes(out)
+
+
+def maybe_compress(data: bytes) -> bytes:
+    """Compress when it helps; otherwise return ``data`` unchanged."""
+    if not should_compress(len(data)):
+        return data
+    out = compress(data)
+    return out if out is not None else data
+
+
+def maybe_decompress(data: bytes) -> bytes:
+    """Expand ODLC lz4_block; pass other buffers through."""
+    if looks_compressed(data):
+        return decompress(data)
+    return data

--- a/bridge/tb_bridge_client.py
+++ b/bridge/tb_bridge_client.py
@@ -157,6 +157,18 @@ class TBBridgeClient:
         else:
             raise TypeError(f"unsupported tensor type: {type(tensor)}")
 
+        try:
+            from bridge.odl_compress import maybe_compress, looks_compressed
+        except ImportError:
+            from odl_compress import maybe_compress, looks_compressed
+
+        packed = maybe_compress(arr_bytes)
+        if looks_compressed(packed):
+            meta["odlc"] = True
+            meta["odlc_algo"] = "lz4_block"
+            meta["raw_bytes"] = len(arr_bytes)
+        arr_bytes = packed
+
         meta_bytes = json.dumps(meta).encode("utf-8")
         key_bytes = key.encode("utf-8")
         if len(key_bytes) > 256:
@@ -199,6 +211,13 @@ class TBBridgeClient:
             return meta, data
 
         meta, data = self._call(do)
+
+        try:
+            from bridge.odl_compress import maybe_decompress
+        except ImportError:
+            from odl_compress import maybe_decompress
+
+        data = maybe_decompress(data)
 
         if meta["kind"] == "torch":
             return self._bytes_to_torch(data, meta, device=device)

--- a/bridge/tb_bridge_server.py
+++ b/bridge/tb_bridge_server.py
@@ -95,15 +95,21 @@ class TensorStore:
             return self._bytes, len(self._store)
 
     def view(self, key: str):
-        """Local MLX (or NumPy) view of a stored blob. See mlx_helpers."""
+        """Local MLX (or NumPy) view. Decompresses ODLC first."""
         entry = self.get(key)
         if entry is None:
             return None
+        meta, data = entry
+        try:
+            from bridge.odl_compress import maybe_decompress
+        except ImportError:
+            from odl_compress import maybe_decompress
+        data = maybe_decompress(data)
         try:
             from mlx_helpers import wrap_blob
         except ImportError:
             from bridge.mlx_helpers import wrap_blob
-        return wrap_blob(entry[0], entry[1])
+        return wrap_blob(meta, data)
 
 
 def _recv_exact(sock: socket.socket, n: int) -> bytes:

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -9,13 +9,15 @@ add_executable(odl_tb5_cli
     src/odl_tb5_cli_jitter.c
     src/odl_tb5_cli_proto.c
     src/odl_tb5_cli_stats.c
+    src/odl_tb5_cli_compress.c
 )
 
 target_include_directories(odl_tb5_cli PRIVATE
     src
     ${CMAKE_SOURCE_DIR}/lib/include
+    ${CMAKE_SOURCE_DIR}/compress/include
 )
-target_link_libraries(odl_tb5_cli odl_tb5 pthread m)
+target_link_libraries(odl_tb5_cli odl_tb5 odl_compress pthread m)
 
 include(GNUInstallDirs)
 install(TARGETS odl_tb5_cli

--- a/cli/src/odl_tb5_cli.h
+++ b/cli/src/odl_tb5_cli.h
@@ -43,6 +43,7 @@ enum odl_cli_test_type {
 	ODL_TEST_LATENCY_LOAD  = 3,
 	ODL_TEST_MIMO          = 4,
 	ODL_TEST_JITTER        = 5,
+	ODL_TEST_COMPRESS      = 6, /* local, no peer — measured LZ4 ratios */
 	ODL_TEST_ALL           = 99,
 };
 
@@ -249,5 +250,8 @@ int odl_cli_mimo_server(odl_tb5_t handle, uint8_t sid, uint8_t dst,
 			 const struct odl_cli_test_req *req);
 int odl_cli_jitter_server(odl_tb5_t handle, uint8_t sid, uint8_t dst,
 			   const struct odl_cli_test_req *req);
+
+/* Local measured ratios. No peer. Safe on Mac. */
+void odl_cli_compress_report(void);
 
 #endif

--- a/cli/src/odl_tb5_cli_client.c
+++ b/cli/src/odl_tb5_cli_client.c
@@ -122,6 +122,11 @@ static int run_single_test(odl_tb5_t handle, uint8_t sid, uint8_t dst,
 		ret = odl_cli_jitter_client(handle, sid, dst, params);
 		break;
 
+	case ODL_TEST_COMPRESS:
+		/* Local. Mac and Linux. No TEST_REQ. */
+		odl_cli_compress_report();
+		return 0;
+
 	default:
 		fprintf(stderr, "Unknown test type: %d\n", test_type);
 		return -EINVAL;
@@ -187,6 +192,7 @@ int odl_cli_run_client(const struct odl_cli_params *params)
 			ODL_TEST_JITTER,
 			ODL_TEST_LATENCY_LOAD,
 			ODL_TEST_MIMO,
+			ODL_TEST_COMPRESS,
 		};
 
 		for (int i = 0; i < (int)(sizeof(all_tests) / sizeof(all_tests[0])); i++) {

--- a/cli/src/odl_tb5_cli_compress.c
+++ b/cli/src/odl_tb5_cli_compress.c
@@ -2,9 +2,7 @@
  * Local compression report. No cable. Runs on Linux and Mac.
  *
  * Prints measured in/wire/ratio for labeled patterns. Does not invent
- * a multiplier. nvCOMP's published numbers (Cascaded ≤80x on analytical
- * numerical data; LZ4/Snappy ≤100 GB/s GPU) are quoted in docs/GPU.md —
- * we do not ship Cascaded, and NVIDIA does not quote a GDeflate ratio.
+ * a multiplier. nvCOMP is not used.
  */
 #include "odl_tb5_cli.h"
 
@@ -87,7 +85,5 @@ void odl_cli_compress_report(void)
 	one_pattern("zeros", fill_zeros, ODL_COMPRESS_BENCH_BYTES);
 	one_pattern("fill-0xAA", fill_aa, ODL_COMPRESS_BENCH_BYTES);
 	one_pattern("random", fill_random, ODL_COMPRESS_BENCH_BYTES);
-	printf("Note: ratio is this pattern on this machine. "
-	       "NVIDIA does not publish a GDeflate/LZ4 ratio; "
-	       "Cascaded (unused here) is up to 80x on analytical numerical data.\n");
+	printf("Note: ratio is this pattern on this machine. nvCOMP is not used.\n");
 }

--- a/cli/src/odl_tb5_cli_compress.c
+++ b/cli/src/odl_tb5_cli_compress.c
@@ -1,0 +1,93 @@
+/*
+ * Local compression report. No cable. Runs on Linux and Mac.
+ *
+ * Prints measured in/wire/ratio for labeled patterns. Does not invent
+ * a multiplier. nvCOMP's published numbers (Cascaded ≤80x on analytical
+ * numerical data; LZ4/Snappy ≤100 GB/s GPU) are quoted in docs/GPU.md —
+ * we do not ship Cascaded, and NVIDIA does not quote a GDeflate ratio.
+ */
+#include "odl_tb5_cli.h"
+
+#include <odl_tb5/odl_compress.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define ODL_COMPRESS_BENCH_BYTES (16u << 20) /* 16 MiB — enough for a stable ratio */
+
+static void fill_zeros(uint8_t *p, size_t n)
+{
+	memset(p, 0, n);
+}
+
+static void fill_aa(uint8_t *p, size_t n)
+{
+	/* Same byte as the bandwidth test. */
+	memset(p, 0xAA, n);
+}
+
+static void fill_random(uint8_t *p, size_t n)
+{
+	uint32_t s = 0xC0FFEEu;
+	size_t i;
+
+	for (i = 0; i < n; i++) {
+		s ^= s << 13;
+		s ^= s >> 17;
+		s ^= s << 5;
+		p[i] = (uint8_t)s;
+	}
+}
+
+static void one_pattern(const char *name, void (*fill)(uint8_t *, size_t),
+			size_t n)
+{
+	uint8_t *in, *wire;
+	size_t cap, wire_n = 0;
+	int rc;
+	double ratio;
+
+	in = malloc(n);
+	cap = odl_compress_host_max_wire_bytes(n);
+	wire = malloc(cap);
+	if (!in || !wire) {
+		free(in);
+		free(wire);
+		printf("Payload %-12s  (oom)\n", name);
+		return;
+	}
+	fill(in, n);
+	rc = odl_compress_host(in, n, wire, cap, &wire_n);
+	if (rc != 0 || wire_n == 0) {
+		printf("Payload %-12s  in=%zu wire=0 ratio=0.00  (incompressible)\n",
+		       name, n);
+		free(in);
+		free(wire);
+		return;
+	}
+	ratio = (double)n / (double)wire_n;
+	printf("Payload %-12s  in=%zu wire=%zu ratio=%.2f\n",
+	       name, n, wire_n, ratio);
+	/* 1 GiB of this payload → how much wire; 1 GiB of wire → how much payload */
+	printf("  1 GiB payload → %.3f GiB wire    1 GiB wire → %.2f GiB payload\n",
+	       1.0 / ratio, ratio);
+	free(in);
+	free(wire);
+}
+
+void odl_cli_compress_report(void)
+{
+	const char *be = "lz4_block host";
+
+	printf("\n=== Compression (measured) ===\n");
+	printf("Backend: %s\n", be);
+	printf("Size: %u bytes per pattern\n", ODL_COMPRESS_BENCH_BYTES);
+	one_pattern("zeros", fill_zeros, ODL_COMPRESS_BENCH_BYTES);
+	one_pattern("fill-0xAA", fill_aa, ODL_COMPRESS_BENCH_BYTES);
+	one_pattern("random", fill_random, ODL_COMPRESS_BENCH_BYTES);
+	printf("Note: ratio is this pattern on this machine. "
+	       "NVIDIA does not publish a GDeflate/LZ4 ratio; "
+	       "Cascaded (unused here) is up to 80x on analytical numerical data.\n");
+}

--- a/cli/src/odl_tb5_cli_main.c
+++ b/cli/src/odl_tb5_cli_main.c
@@ -29,7 +29,7 @@ static void print_usage(const char *prog)
 		"  -o <file>       Output results to CSV file\n"
 		"\n"
 		"Client options:\n"
-		"  -t <test>       Test type: bandwidth|latency|latency-load|mimo|jitter|all\n"
+		"  -t <test>       Test type: bandwidth|latency|latency-load|mimo|jitter|compress|all\n"
 		"  -b <sizes>      Block sizes, comma-separated (e.g., 4K,64K,1M,4M)\n"
 		"  -i <count>      Iteration count (default: 1000 for latency, 100 for bw)\n"
 		"  -D <seconds>    Duration per test (default: 10)\n"
@@ -81,6 +81,8 @@ static enum odl_cli_test_type parse_test_type(const char *str)
 		return ODL_TEST_MIMO;
 	if (strcmp(str, "jitter") == 0)
 		return ODL_TEST_JITTER;
+	if (strcmp(str, "compress") == 0 || strcmp(str, "odlc") == 0)
+		return ODL_TEST_COMPRESS;
 	if (strcmp(str, "all") == 0)
 		return ODL_TEST_ALL;
 
@@ -204,6 +206,12 @@ int main(int argc, char *argv[])
 	if (is_client && !params.test_type) {
 		fprintf(stderr, "Client mode requires -t <test>\n");
 		return 1;
+	}
+
+	/* Local only — no /dev, works on a Mac or a box with no NHI. */
+	if (params.test_type == ODL_TEST_COMPRESS) {
+		odl_cli_compress_report();
+		return 0;
 	}
 
 	if (is_server)

--- a/compress/CMakeLists.txt
+++ b/compress/CMakeLists.txt
@@ -38,6 +38,8 @@ if(NOT ODL_ENABLE_NVCOMP STREQUAL "OFF")
     list(APPEND _nvcomp_hints
       "$ENV{HOME}/miniconda3/lib/python3.13/site-packages/nvidia/libnvcomp"
       "$ENV{HOME}/miniconda3/lib/python3.12/site-packages/nvidia/libnvcomp"
+      "$ENV{HOME}/miniconda3/lib/python3.13/site-packages/nvidia/libnvcomp_cu13"
+      "$ENV{HOME}/miniconda3/lib/python3.12/site-packages/nvidia/libnvcomp_cu13"
     )
   endif()
 
@@ -77,8 +79,8 @@ if(NOT ODL_ENABLE_NVCOMP STREQUAL "OFF")
       "nvcomp-local-repo-ubuntu2604-5.3.0_5.3.0-1_amd64.deb\n"
       "    sudo dpkg -i nvcomp-local-repo-ubuntu2604-5.3.0_5.3.0-1_amd64.deb\n"
       "    sudo cp /var/nvcomp-local-repo-ubuntu2604-5.3.0/nvcomp-*-keyring.gpg /usr/share/keyrings/\n"
-      "    sudo apt-get update && sudo apt-get -y install nvcomp\n"
-      "  Or: pip install nvidia-nvcomp-cu12  and set\n"
+      "    sudo apt-get update && sudo apt-get -y install nvcomp-cuda-12   # or nvcomp-cuda-13\n"
+      "  Or: pip install nvidia-libnvcomp-cu12   # or nvidia-libnvcomp-cu13\n"
       "    -DNVCOMP_ROOT=$CONDA_PREFIX/lib/python3.x/site-packages/nvidia/libnvcomp\n"
       "  Falling back to stub (compression disabled at runtime).")
   elseif(ODL_NVCOMP_FOUND)

--- a/compress/CMakeLists.txt
+++ b/compress/CMakeLists.txt
@@ -92,9 +92,21 @@ if(NOT ODL_ENABLE_NVCOMP STREQUAL "OFF")
 endif()
 
 # Always produce libodl_compress so NCCL can link unconditionally.
+# Host LZ4 (algo 4) is always compiled — that is the Mac-readable format.
 add_library(odl_compress SHARED
   src/odl_compress_common.c
+  src/odl_compress_lz4.c
+  third_party/lz4/lz4.c
 )
+
+target_include_directories(odl_compress
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/lz4
+)
+
+if(APPLE)
+  target_link_libraries(odl_compress PRIVATE "-framework Compression")
+endif()
 
 target_include_directories(odl_compress
   PUBLIC
@@ -146,3 +158,9 @@ if(ODL_NVCOMP_FOUND)
   target_include_directories(odl_compress_bench PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include)
 endif()
+
+# Host LZ4 round-trip — no CUDA, runs on Linux and Mac CI.
+add_executable(odl_compress_host_test tests/odl_compress_host_test.c)
+target_link_libraries(odl_compress_host_test PRIVATE odl_compress)
+target_include_directories(odl_compress_host_test PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/compress/CMakeLists.txt
+++ b/compress/CMakeLists.txt
@@ -1,100 +1,11 @@
-# Optional GPU compression (nvCOMP). Never fails the rest of the tree.
-#
-#   cmake -DODL_ENABLE_NVCOMP=ON|OFF|AUTO   (default AUTO)
-#   -DNVCOMP_ROOT=/path/to/nvcomp           (optional hint)
-#
-# Without nvCOMP, a stub backend is linked: odl_compress_enabled() is always 0
-# and NCCL keeps the uncompressed path.
+# Host LZ4 only (ODLC algo 4). nvCOMP is not wired: it does not shrink
+# NCCL DMA (fixed max_wire), a Mac cannot decode GDeflate, and GeForce
+# Blackwell has no decompress engine. odl_nvcomp.cpp stays in the tree
+# unused.
 
-option(ODL_ENABLE_NVCOMP "Build nvCOMP compression backend (ON/OFF/AUTO)" AUTO)
+message(STATUS "odl_compress: host LZ4 (nvCOMP not linked)")
 
-set(ODL_NVCOMP_FOUND FALSE)
-set(ODL_NVCOMP_INCLUDE_DIR "")
-set(ODL_NVCOMP_LIBRARY "")
-
-if(NOT ODL_ENABLE_NVCOMP STREQUAL "OFF")
-  # Search order: explicit root, system prefix, pip/conda nvidia wheel layout
-  set(_nvcomp_hints "")
-  if(NVCOMP_ROOT)
-    list(APPEND _nvcomp_hints "${NVCOMP_ROOT}")
-  endif()
-  if(DEFINED ENV{NVCOMP_ROOT})
-    list(APPEND _nvcomp_hints "$ENV{NVCOMP_ROOT}")
-  endif()
-  list(APPEND _nvcomp_hints
-    /usr
-    /usr/local
-    /usr/local/cuda
-  )
-  if(DEFINED ENV{CONDA_PREFIX})
-    list(APPEND _nvcomp_hints
-      "$ENV{CONDA_PREFIX}"
-      "$ENV{CONDA_PREFIX}/lib/python3.13/site-packages/nvidia/libnvcomp"
-      "$ENV{CONDA_PREFIX}/lib/python3.12/site-packages/nvidia/libnvcomp"
-      "$ENV{CONDA_PREFIX}/lib/python3.11/site-packages/nvidia/libnvcomp"
-    )
-  endif()
-  if(DEFINED ENV{HOME})
-    list(APPEND _nvcomp_hints
-      "$ENV{HOME}/miniconda3/lib/python3.13/site-packages/nvidia/libnvcomp"
-      "$ENV{HOME}/miniconda3/lib/python3.12/site-packages/nvidia/libnvcomp"
-      "$ENV{HOME}/miniconda3/lib/python3.13/site-packages/nvidia/libnvcomp_cu13"
-      "$ENV{HOME}/miniconda3/lib/python3.12/site-packages/nvidia/libnvcomp_cu13"
-    )
-  endif()
-
-  # Manual scan — more reliable than find_* for pip wheels that lack unversioned .so
-  foreach(_root ${_nvcomp_hints})
-    if(NOT ODL_NVCOMP_INCLUDE_DIR AND EXISTS "${_root}/include/nvcomp/nvcompManager.hpp")
-      set(ODL_NVCOMP_INCLUDE_DIR "${_root}/include")
-    endif()
-    if(NOT ODL_NVCOMP_INCLUDE_DIR AND EXISTS "${_root}/nvcomp/nvcompManager.hpp")
-      set(ODL_NVCOMP_INCLUDE_DIR "${_root}")
-    endif()
-    if(NOT ODL_NVCOMP_LIBRARY AND EXISTS "${_root}/lib64/libnvcomp.so.5")
-      set(ODL_NVCOMP_LIBRARY "${_root}/lib64/libnvcomp.so.5")
-    endif()
-    if(NOT ODL_NVCOMP_LIBRARY AND EXISTS "${_root}/lib/libnvcomp.so.5")
-      set(ODL_NVCOMP_LIBRARY "${_root}/lib/libnvcomp.so.5")
-    endif()
-    if(NOT ODL_NVCOMP_LIBRARY AND EXISTS "${_root}/lib64/libnvcomp.so")
-      set(ODL_NVCOMP_LIBRARY "${_root}/lib64/libnvcomp.so")
-    endif()
-  endforeach()
-
-  find_package(CUDAToolkit QUIET)
-  if(ODL_NVCOMP_INCLUDE_DIR AND ODL_NVCOMP_LIBRARY AND CUDAToolkit_FOUND)
-    set(ODL_NVCOMP_FOUND TRUE)
-  else()
-    message(STATUS
-      "nvCOMP probe: include=${ODL_NVCOMP_INCLUDE_DIR} lib=${ODL_NVCOMP_LIBRARY} "
-      "cuda=${CUDAToolkit_FOUND}")
-  endif()
-
-  if(ODL_ENABLE_NVCOMP STREQUAL "ON" AND NOT ODL_NVCOMP_FOUND)
-    message(WARNING
-      "ODL_ENABLE_NVCOMP=ON but nvCOMP/CUDAToolkit not found.\n"
-      "  Install (optional):\n"
-      "    wget https://developer.download.nvidia.com/compute/nvcomp/5.3.0/local_installers/"
-      "nvcomp-local-repo-ubuntu2604-5.3.0_5.3.0-1_amd64.deb\n"
-      "    sudo dpkg -i nvcomp-local-repo-ubuntu2604-5.3.0_5.3.0-1_amd64.deb\n"
-      "    sudo cp /var/nvcomp-local-repo-ubuntu2604-5.3.0/nvcomp-*-keyring.gpg /usr/share/keyrings/\n"
-      "    sudo apt-get update && sudo apt-get -y install nvcomp-cuda-12   # or nvcomp-cuda-13\n"
-      "  Or: pip install nvidia-libnvcomp-cu12   # or nvidia-libnvcomp-cu13\n"
-      "    -DNVCOMP_ROOT=$CONDA_PREFIX/lib/python3.x/site-packages/nvidia/libnvcomp\n"
-      "  Falling back to stub (compression disabled at runtime).")
-  elseif(ODL_NVCOMP_FOUND)
-    message(STATUS "nvCOMP found: ${ODL_NVCOMP_LIBRARY}")
-    message(STATUS "nvCOMP include: ${ODL_NVCOMP_INCLUDE_DIR}")
-  else()
-    message(STATUS
-      "nvCOMP not found — building compress stub (ODL_COMPRESS no-ops). "
-      "Optional install: see docs/GPU.md §Compression")
-  endif()
-endif()
-
-# Always produce libodl_compress so NCCL can link unconditionally.
-# Host LZ4 (algo 4) is always compiled — that is the Mac-readable format.
+# Host LZ4 (algo 4) — Mac-readable format.
 add_library(odl_compress SHARED
   src/odl_compress_common.c
   src/odl_compress_lz4.c
@@ -116,26 +27,7 @@ target_include_directories(odl_compress
     $<INSTALL_INTERFACE:include>
 )
 
-if(ODL_NVCOMP_FOUND)
-  enable_language(CXX)
-  target_sources(odl_compress PRIVATE src/odl_nvcomp.cpp)
-  target_compile_definitions(odl_compress PRIVATE ODL_HAS_NVCOMP=1)
-  target_include_directories(odl_compress PRIVATE
-    ${ODL_NVCOMP_INCLUDE_DIR}
-    ${CUDAToolkit_INCLUDE_DIRS}
-  )
-  target_link_libraries(odl_compress PRIVATE
-    ${ODL_NVCOMP_LIBRARY}
-    CUDA::cudart
-  )
-  # C++ ABI
-  set_target_properties(odl_compress PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-  )
-else()
-  target_sources(odl_compress PRIVATE src/odl_compress_stub.c)
-endif()
+target_sources(odl_compress PRIVATE src/odl_compress_stub.c)
 
 set_target_properties(odl_compress PROPERTIES
   VERSION ${PROJECT_VERSION}
@@ -152,14 +44,6 @@ install(DIRECTORY include/odl_tb5
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   COMPONENT compress
 )
-
-# Optional micro-bench (only with real nvCOMP)
-if(ODL_NVCOMP_FOUND)
-  add_executable(odl_compress_bench tests/odl_compress_bench.cpp)
-  target_link_libraries(odl_compress_bench PRIVATE odl_compress CUDA::cudart)
-  target_include_directories(odl_compress_bench PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include)
-endif()
 
 # Host LZ4 round-trip — no CUDA, runs on Linux and Mac CI.
 add_executable(odl_compress_host_test tests/odl_compress_host_test.c)

--- a/compress/include/odl_tb5/odl_compress.h
+++ b/compress/include/odl_tb5/odl_compress.h
@@ -5,14 +5,9 @@
  * Wire (little-endian, packed):
  *   [odl_compress_header | payload]
  *
- * Two payload families share this header:
- *
- *   1) nvCOMP native (Linux CUDA only) — algo 1/2/3
- *      GDeflate / batched LZ4 / Snappy from nvCOMP managers.
- *      A Mac cannot decode these. Linux↔Linux NCCL only.
- *
- *   2) Portable LZ4 blocks — algo 4 (ODL_ALGO_LZ4_BLOCK)
- *      This is what the Mac and the TB-bridge speak.
+ * We only write portable LZ4 blocks — algo 4 (ODL_ALGO_LZ4_BLOCK).
+ * Algo 1–3 (nvCOMP GDeflate / batched LZ4 / Snappy) are rejected.
+ * nvCOMP is not linked.
  *
  *      payload:
  *        num_chunks × { u32 raw_bytes, u32 comp_bytes }   (LE)
@@ -22,14 +17,9 @@
  *      compressed_bytes = table + all blocks. Chunks are 64 KiB
  *      except the last. Empty input is never wrapped.
  *
- * Env:
- *   ODL_COMPRESS=1
- *   ODL_COMPRESS_ALGO=gdeflate|lz4|snappy|lz4_block
+ * Env (bridge / host):
+ *   ODL_COMPRESS=0 to disable (on by default for the bridge)
  *   ODL_COMPRESS_THRESHOLD=262144
- *   ODL_COMPRESS_LEVEL=1
- *
- * NCCL (CUDA) uses gdeflate/lz4/snappy when nvCOMP is linked.
- * The Mac / bridge path always writes and reads lz4_block.
  */
 #pragma once
 

--- a/compress/include/odl_tb5/odl_compress.h
+++ b/compress/include/odl_tb5/odl_compress.h
@@ -1,15 +1,35 @@
 /* SPDX-License-Identifier: MIT */
 /**
- * OdinLink optional GPU compression (nvCOMP) for the TB link path.
+ * OdinLink optional compression for the TB link path.
  *
- * Wire format when compression is used:
- *   [odl_compress_header | compressed payload | optional padding to max]
+ * Wire (little-endian, packed):
+ *   [odl_compress_header | payload]
  *
- * Env (both peers should match):
+ * Two payload families share this header:
+ *
+ *   1) nvCOMP native (Linux CUDA only) — algo 1/2/3
+ *      GDeflate / batched LZ4 / Snappy from nvCOMP managers.
+ *      A Mac cannot decode these. Linux↔Linux NCCL only.
+ *
+ *   2) Portable LZ4 blocks — algo 4 (ODL_ALGO_LZ4_BLOCK)
+ *      This is what the Mac and the TB-bridge speak.
+ *
+ *      payload:
+ *        num_chunks × { u32 raw_bytes, u32 comp_bytes }   (LE)
+ *        then concatenated standard LZ4 raw blocks
+ *        (LZ4_compress_default / Apple COMPRESSION_LZ4_RAW)
+ *
+ *      compressed_bytes = table + all blocks. Chunks are 64 KiB
+ *      except the last. Empty input is never wrapped.
+ *
+ * Env:
  *   ODL_COMPRESS=1
- *   ODL_COMPRESS_ALGO=gdeflate|lz4|snappy
+ *   ODL_COMPRESS_ALGO=gdeflate|lz4|snappy|lz4_block
  *   ODL_COMPRESS_THRESHOLD=262144
  *   ODL_COMPRESS_LEVEL=1
+ *
+ * NCCL (CUDA) uses gdeflate/lz4/snappy when nvCOMP is linked.
+ * The Mac / bridge path always writes and reads lz4_block.
  */
 #pragma once
 
@@ -20,14 +40,16 @@
 extern "C" {
 #endif
 
-#define ODL_COMPRESS_MAGIC   0x4F444C43u /* 'ODLC' */
+#define ODL_COMPRESS_MAGIC   0x4F444C43u /* 'ODLC' as LE u32 */
 #define ODL_COMPRESS_VERSION 1
+#define ODL_COMPRESS_CHUNK   65536u
 
 enum odl_compress_algo {
-	ODL_ALGO_NONE     = 0,
-	ODL_ALGO_GDEFLATE = 1,
-	ODL_ALGO_LZ4      = 2,
-	ODL_ALGO_SNAPPY   = 3,
+	ODL_ALGO_NONE      = 0,
+	ODL_ALGO_GDEFLATE  = 1, /* nvCOMP only */
+	ODL_ALGO_LZ4       = 2, /* nvCOMP batched LZ4 — not Mac-readable */
+	ODL_ALGO_SNAPPY    = 3, /* nvCOMP only */
+	ODL_ALGO_LZ4_BLOCK = 4, /* portable, Mac + host */
 };
 
 struct odl_compress_header {
@@ -38,6 +60,11 @@ struct odl_compress_header {
 	uint64_t compressed_bytes;
 	uint32_t num_chunks;
 	uint32_t reserved;
+} __attribute__((packed));
+
+struct odl_lz4_chunk {
+	uint32_t raw_bytes;
+	uint32_t comp_bytes;
 } __attribute__((packed));
 
 /* ── config ──────────────────────────────────────────────────────── */
@@ -93,10 +120,45 @@ void *odl_compress_device_alloc(size_t bytes);
 void odl_compress_device_free(void *ptr);
 
 /**
- * Should this message try compression? (enabled + size >= threshold + backend).
- * type_is_cuda: 1 for GPU pointers, 0 for host (v1 host compress not implemented).
+ * Should this message try GPU compression? (enabled + size + nvCOMP).
+ * type_is_cuda: 1 for GPU pointers. Host always returns 0 here —
+ * use odl_compress_should_host() for the Mac/bridge path.
  */
 int odl_compress_should(size_t size, int type_is_cuda);
+
+/* ── Host / Mac portable LZ4 (algo 4) ────────────────────────────── */
+
+/** Always 1 — vendored LZ4, no nvCOMP required. */
+int odl_compress_host_available(void);
+
+/** 1 if ODL_COMPRESS is on and host LZ4 is available. */
+int odl_compress_host_enabled(void);
+
+/** 1 if size >= threshold and host compression is enabled. */
+int odl_compress_should_host(size_t size);
+
+/** Upper bound on an lz4_block wire blob for `original_bytes`. */
+size_t odl_compress_host_max_wire_bytes(size_t original_bytes);
+
+/**
+ * Compress host buffer into ODLC + lz4_block.
+ * Returns 0 on success (and *out_wire_bytes < in_bytes).
+ * Returns -1 to keep the raw payload (incompressible / error).
+ */
+int odl_compress_host(const void *in, size_t in_bytes,
+		      void *out, size_t out_capacity,
+		      size_t *out_wire_bytes);
+
+/**
+ * Decompress an ODLC lz4_block blob. Rejects nvCOMP algos (1/2/3).
+ * d_out must hold header.original_bytes.
+ */
+int odl_decompress_host(const void *wire, size_t wire_bytes,
+			void *out, size_t out_capacity,
+			size_t *out_original_bytes);
+
+/** 1 if buf starts with a valid ODLC header. */
+int odl_compress_looks_compressed(const void *buf, size_t n);
 
 #ifdef __cplusplus
 }

--- a/compress/src/odl_compress_common.c
+++ b/compress/src/odl_compress_common.c
@@ -13,7 +13,7 @@ extern int odl_compress_backend_available(void);
 
 static int g_inited;
 static int g_want; /* ODL_COMPRESS=1 */
-static int g_algo = ODL_ALGO_GDEFLATE;
+static int g_algo = ODL_ALGO_LZ4_BLOCK;
 static size_t g_threshold = 262144;
 
 static int env_truthy(const char *v)

--- a/compress/src/odl_compress_common.c
+++ b/compress/src/odl_compress_common.c
@@ -53,6 +53,9 @@ int odl_compress_init(void)
 			g_algo = ODL_ALGO_LZ4;
 		else if (strcasecmp(algo, "snappy") == 0)
 			g_algo = ODL_ALGO_SNAPPY;
+		else if (strcasecmp(algo, "lz4_block") == 0 ||
+			 strcasecmp(algo, "lz4block") == 0)
+			g_algo = ODL_ALGO_LZ4_BLOCK;
 		else if (strcasecmp(algo, "none") == 0)
 			g_algo = ODL_ALGO_NONE;
 	}

--- a/compress/src/odl_compress_lz4.c
+++ b/compress/src/odl_compress_lz4.c
@@ -1,0 +1,250 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Portable ODLC + LZ4 raw-block codec. No CUDA. Builds on Linux and Mac.
+ * This is the format the Mac (bridge, Compression.framework, this file)
+ * can actually decode. nvCOMP GDeflate/batched-LZ4 stays Linux-GPU-only.
+ */
+#include <odl_tb5/odl_compress.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "lz4.h"
+
+#ifdef __APPLE__
+#include <compression.h>
+#endif
+
+extern int odl_compress_init(void);
+
+int odl_compress_host_available(void)
+{
+	return 1;
+}
+
+static int host_wanted(void)
+{
+	const char *en = getenv("ODL_COMPRESS");
+
+	/* On unless explicitly off. NCCL still requires ODL_COMPRESS=1
+	 * plus nvCOMP — see odl_compress_enabled(). */
+	if (!en || !*en)
+		return 1;
+	if (en[0] == '0' && en[1] == '\0')
+		return 0;
+	if (strcasecmp(en, "false") == 0 || strcasecmp(en, "off") == 0 ||
+	    strcasecmp(en, "no") == 0)
+		return 0;
+	return 1;
+}
+
+int odl_compress_host_enabled(void)
+{
+	return host_wanted();
+}
+
+int odl_compress_should_host(size_t size)
+{
+	if (!host_wanted())
+		return 0;
+	if (size < odl_compress_threshold())
+		return 0;
+	return 1;
+}
+
+size_t odl_compress_host_max_wire_bytes(size_t original_bytes)
+{
+	size_t n, i, raw, bound;
+
+	if (original_bytes == 0)
+		return sizeof(struct odl_compress_header);
+	n = (original_bytes + ODL_COMPRESS_CHUNK - 1) / ODL_COMPRESS_CHUNK;
+	bound = sizeof(struct odl_compress_header) +
+		n * sizeof(struct odl_lz4_chunk);
+	for (i = 0; i < n; i++) {
+		raw = original_bytes - i * ODL_COMPRESS_CHUNK;
+		if (raw > ODL_COMPRESS_CHUNK)
+			raw = ODL_COMPRESS_CHUNK;
+		bound += (size_t)LZ4_compressBound((int)raw);
+	}
+	return bound;
+}
+
+int odl_compress_looks_compressed(const void *buf, size_t n)
+{
+	struct odl_compress_header hdr;
+
+	if (!buf || n < sizeof(hdr))
+		return 0;
+	memcpy(&hdr, buf, sizeof(hdr));
+	return odl_compress_header_ok(&hdr);
+}
+
+#ifdef __APPLE__
+static int apple_lz4_compress(const void *in, int in_n, void *out, int out_cap)
+{
+	size_t n;
+
+	if (in_n <= 0 || out_cap <= 0)
+		return 0;
+	n = compression_encode_buffer(out, (size_t)out_cap, in, (size_t)in_n,
+				      NULL, COMPRESSION_LZ4_RAW);
+	if (n == 0)
+		return 0;
+	return (int)n;
+}
+
+static int apple_lz4_decompress(const void *in, int in_n, void *out, int out_cap)
+{
+	size_t n;
+
+	if (in_n <= 0 || out_cap <= 0)
+		return 0;
+	n = compression_decode_buffer(out, (size_t)out_cap, in, (size_t)in_n,
+				      NULL, COMPRESSION_LZ4_RAW);
+	if (n == 0)
+		return 0;
+	return (int)n;
+}
+#endif
+
+static int block_compress(const void *in, int in_n, void *out, int out_cap)
+{
+#ifdef __APPLE__
+	int n = apple_lz4_compress(in, in_n, out, out_cap);
+	if (n > 0)
+		return n;
+#endif
+	return LZ4_compress_default(in, out, in_n, out_cap);
+}
+
+static int block_decompress(const void *in, int in_n, void *out, int out_cap)
+{
+#ifdef __APPLE__
+	int n = apple_lz4_decompress(in, in_n, out, out_cap);
+	if (n > 0)
+		return n;
+#endif
+	return LZ4_decompress_safe(in, out, in_n, out_cap);
+}
+
+int odl_compress_host(const void *in, size_t in_bytes,
+		      void *out, size_t out_capacity,
+		      size_t *out_wire_bytes)
+{
+	const uint8_t *src = in;
+	uint8_t *dst = out;
+	struct odl_compress_header hdr;
+	struct odl_lz4_chunk *table;
+	size_t nchunks, i, off, table_bytes, payload;
+	uint8_t *blocks;
+
+	if (!in || !out || !out_wire_bytes || in_bytes == 0)
+		return -1;
+	if (out_capacity < odl_compress_host_max_wire_bytes(in_bytes) &&
+	    out_capacity < sizeof(hdr) + sizeof(struct odl_lz4_chunk) + in_bytes)
+		return -1;
+
+	nchunks = (in_bytes + ODL_COMPRESS_CHUNK - 1) / ODL_COMPRESS_CHUNK;
+	table_bytes = nchunks * sizeof(struct odl_lz4_chunk);
+	if (sizeof(hdr) + table_bytes > out_capacity)
+		return -1;
+
+	table = (struct odl_lz4_chunk *)(dst + sizeof(hdr));
+	blocks = dst + sizeof(hdr) + table_bytes;
+	off = 0;
+	payload = 0;
+
+	for (i = 0; i < nchunks; i++) {
+		size_t raw = in_bytes - i * ODL_COMPRESS_CHUNK;
+		int c;
+		int cap;
+
+		if (raw > ODL_COMPRESS_CHUNK)
+			raw = ODL_COMPRESS_CHUNK;
+		if (sizeof(hdr) + table_bytes + payload >= out_capacity)
+			return -1;
+		cap = (int)(out_capacity - sizeof(hdr) - table_bytes - payload);
+		c = block_compress(src + off, (int)raw, blocks + payload, cap);
+		if (c <= 0)
+			return -1;
+		table[i].raw_bytes = (uint32_t)raw;
+		table[i].comp_bytes = (uint32_t)c;
+		payload += (size_t)c;
+		off += raw;
+	}
+
+	if (sizeof(hdr) + table_bytes + payload >= in_bytes)
+		return -1; /* not worth it */
+
+	memset(&hdr, 0, sizeof(hdr));
+	hdr.magic = ODL_COMPRESS_MAGIC;
+	hdr.version = ODL_COMPRESS_VERSION;
+	hdr.algo = ODL_ALGO_LZ4_BLOCK;
+	hdr.original_bytes = in_bytes;
+	hdr.compressed_bytes = table_bytes + payload;
+	hdr.num_chunks = (uint32_t)nchunks;
+	memcpy(dst, &hdr, sizeof(hdr));
+
+	*out_wire_bytes = sizeof(hdr) + table_bytes + payload;
+	return 0;
+}
+
+int odl_decompress_host(const void *wire, size_t wire_bytes,
+			void *out, size_t out_capacity,
+			size_t *out_original_bytes)
+{
+	const uint8_t *src = wire;
+	uint8_t *dst = out;
+	struct odl_compress_header hdr;
+	const struct odl_lz4_chunk *table;
+	size_t table_bytes, i, raw_off, comp_off;
+	const uint8_t *blocks;
+
+	if (!wire || !out || wire_bytes < sizeof(hdr))
+		return -1;
+	memcpy(&hdr, src, sizeof(hdr));
+	if (!odl_compress_header_ok(&hdr))
+		return -1;
+	if (hdr.algo != ODL_ALGO_LZ4_BLOCK)
+		return -1; /* nvCOMP blob — Mac cannot decode */
+	if (hdr.original_bytes > out_capacity)
+		return -1;
+	if (hdr.num_chunks == 0)
+		return -1;
+	table_bytes = (size_t)hdr.num_chunks * sizeof(struct odl_lz4_chunk);
+	if (sizeof(hdr) + hdr.compressed_bytes > wire_bytes)
+		return -1;
+	if (hdr.compressed_bytes < table_bytes)
+		return -1;
+
+	table = (const struct odl_lz4_chunk *)(src + sizeof(hdr));
+	blocks = src + sizeof(hdr) + table_bytes;
+	raw_off = 0;
+	comp_off = 0;
+
+	for (i = 0; i < hdr.num_chunks; i++) {
+		int n;
+		uint32_t raw = table[i].raw_bytes;
+		uint32_t comp = table[i].comp_bytes;
+
+		if (raw == 0 || raw > ODL_COMPRESS_CHUNK)
+			return -1;
+		if (raw_off + raw > hdr.original_bytes)
+			return -1;
+		if (comp_off + comp > hdr.compressed_bytes - table_bytes)
+			return -1;
+		n = block_decompress(blocks + comp_off, (int)comp,
+				     dst + raw_off, (int)raw);
+		if (n != (int)raw)
+			return -1;
+		raw_off += raw;
+		comp_off += comp;
+	}
+	if (raw_off != hdr.original_bytes)
+		return -1;
+	if (out_original_bytes)
+		*out_original_bytes = hdr.original_bytes;
+	return 0;
+}

--- a/compress/src/odl_compress_stub.c
+++ b/compress/src/odl_compress_stub.c
@@ -14,8 +14,8 @@ int odl_compress_backend_available(void)
 
 size_t odl_compress_max_wire_bytes(size_t original_bytes)
 {
-	/* No compression — wire size is the raw payload. */
-	return original_bytes;
+	/* No nvCOMP. Host LZ4 bound is still a valid staging size. */
+	return odl_compress_host_max_wire_bytes(original_bytes);
 }
 
 int odl_compress_gpu(const void *d_in, size_t in_bytes,

--- a/compress/tests/odl_compress_host_test.c
+++ b/compress/tests/odl_compress_host_test.c
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: MIT */
+/* Portable ODLC + LZ4 host round-trip. No CUDA. */
+#include <odl_tb5/odl_compress.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int fail(const char *msg)
+{
+	fprintf(stderr, "FAIL: %s\n", msg);
+	return 1;
+}
+
+static int roundtrip(const uint8_t *src, size_t n, const char *tag)
+{
+	size_t cap = odl_compress_host_max_wire_bytes(n);
+	uint8_t *wire = malloc(cap);
+	uint8_t *out = malloc(n);
+	size_t wire_n = 0, out_n = 0;
+	struct odl_compress_header hdr;
+	int rc;
+
+	if (!wire || !out)
+		return fail("oom");
+
+	rc = odl_compress_host(src, n, wire, cap, &wire_n);
+	if (rc != 0) {
+		free(wire);
+		free(out);
+		fprintf(stderr, "FAIL: %s compress rc=%d\n", tag, rc);
+		return 1;
+	}
+	if (wire_n >= n)
+		return fail("wire not smaller");
+	if (!odl_compress_looks_compressed(wire, wire_n))
+		return fail("magic missing");
+	memcpy(&hdr, wire, sizeof(hdr));
+	if (hdr.algo != ODL_ALGO_LZ4_BLOCK)
+		return fail("algo is not lz4_block");
+	if (hdr.original_bytes != n)
+		return fail("original_bytes");
+
+	if (odl_decompress_host(wire, wire_n, out, n, &out_n) != 0)
+		return fail("decompress");
+	if (out_n != n)
+		return fail("out size");
+	if (memcmp(src, out, n) != 0)
+		return fail("mismatch");
+
+	printf("ok %s in=%zu wire=%zu ratio=%.3f chunks=%u\n",
+	       tag, n, wire_n, (double)n / (double)wire_n, hdr.num_chunks);
+	free(wire);
+	free(out);
+	return 0;
+}
+
+int main(void)
+{
+	size_t n = 3 * 65536 + 100;
+	uint8_t *rep = malloc(n);
+	uint8_t *mix = malloc(n);
+	size_t i;
+	int rc = 0;
+
+	if (!rep || !mix)
+		return fail("oom");
+
+	for (i = 0; i < n; i++)
+		rep[i] = (uint8_t)(i & 0x3f);
+	for (i = 0; i < n; i++)
+		mix[i] = (uint8_t)((i * 1103515245u + 12345u) >> 16);
+
+	/* Header + table is 40 bytes; need enough input to win. */
+	if (roundtrip(rep, 4096, "4k") != 0)
+		rc = 1;
+	if (roundtrip(rep, 65536, "one-chunk") != 0)
+		rc = 1;
+	if (roundtrip(rep, n, "multi-chunk") != 0)
+		rc = 1;
+
+	/* Random data must either fail (not worth it) or round-trip. */
+	{
+		size_t cap = odl_compress_host_max_wire_bytes(n);
+		uint8_t *wire = malloc(cap);
+		size_t wire_n = 0;
+		int c = odl_compress_host(mix, n, wire, cap, &wire_n);
+		if (c == 0) {
+			uint8_t *out = malloc(n);
+			size_t out_n = 0;
+			if (odl_decompress_host(wire, wire_n, out, n, &out_n) != 0 ||
+			    out_n != n || memcmp(mix, out, n) != 0)
+				rc = fail("random round-trip");
+			else
+				printf("ok random in=%zu wire=%zu\n", n, wire_n);
+			free(out);
+		} else {
+			printf("ok random incompressible (fallback raw)\n");
+		}
+		free(wire);
+	}
+
+	/* Reject nvCOMP-looking header (algo=1). */
+	{
+		struct odl_compress_header fake = {
+			.magic = ODL_COMPRESS_MAGIC,
+			.version = ODL_COMPRESS_VERSION,
+			.algo = ODL_ALGO_GDEFLATE,
+			.original_bytes = 8,
+			.compressed_bytes = 8,
+			.num_chunks = 1,
+		};
+		uint8_t buf[sizeof(fake) + 8];
+		uint8_t out[8];
+		size_t out_n = 0;
+		memcpy(buf, &fake, sizeof(fake));
+		if (odl_decompress_host(buf, sizeof(buf), out, 8, &out_n) == 0)
+			rc = fail("accepted gdeflate");
+		else
+			printf("ok rejected nvCOMP gdeflate\n");
+	}
+
+	free(rep);
+	free(mix);
+	return rc;
+}

--- a/compress/tests/test_odl_compress.py
+++ b/compress/tests/test_odl_compress.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""ODLC lz4_block codec tests. No Thunderbolt, no CUDA.
+
+    python3 compress/tests/test_odl_compress.py
+"""
+from __future__ import annotations
+
+import os
+import struct
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT))
+
+from bridge.odl_compress import (  # noqa: E402
+    ALGO_GDEFLATE,
+    ALGO_LZ4_BLOCK,
+    HDR_FMT,
+    MAGIC,
+    VERSION,
+    backend_name,
+    compress,
+    decompress,
+    looks_compressed,
+    maybe_compress,
+    maybe_decompress,
+    should_compress,
+)
+
+
+class FormatTests(unittest.TestCase):
+    def test_reject_empty(self):
+        self.assertIsNone(compress(b""))
+        self.assertFalse(looks_compressed(b""))
+        self.assertFalse(looks_compressed(b"not-odlc"))
+
+    def test_reject_gdeflate_header(self):
+        hdr = struct.pack(HDR_FMT, MAGIC, VERSION, ALGO_GDEFLATE, 8, 8, 1, 0)
+        blob = hdr + b"\x00" * 8
+        with self.assertRaises(ValueError):
+            decompress(blob)
+
+
+@unittest.skipIf(backend_name() == "none", "no LZ4 backend on this machine")
+class RoundTripTests(unittest.TestCase):
+    def test_backend_named(self):
+        self.assertNotEqual(backend_name(), "none")
+
+    def test_repeated_pattern(self):
+        src = bytes([i & 0x3F for i in range(200_000)])
+        wire = compress(src)
+        self.assertIsNotNone(wire)
+        self.assertTrue(looks_compressed(wire))
+        self.assertLess(len(wire), len(src))
+        magic, ver, algo, orig, comp, nchunks, _ = struct.unpack(
+            HDR_FMT, wire[: struct.calcsize(HDR_FMT)]
+        )
+        self.assertEqual(magic, MAGIC)
+        self.assertEqual(ver, VERSION)
+        self.assertEqual(algo, ALGO_LZ4_BLOCK)
+        self.assertEqual(orig, len(src))
+        self.assertGreater(nchunks, 1)
+        self.assertEqual(decompress(wire), src)
+
+    def test_maybe_helpers(self):
+        src = bytes([7]) * 300_000
+        packed = maybe_compress(src)
+        self.assertTrue(looks_compressed(packed))
+        self.assertEqual(maybe_decompress(packed), src)
+        raw = b"hello"
+        self.assertEqual(maybe_decompress(raw), raw)
+
+    def test_threshold_env(self):
+        old = os.environ.get("ODL_COMPRESS")
+        old_t = os.environ.get("ODL_COMPRESS_THRESHOLD")
+        try:
+            os.environ["ODL_COMPRESS"] = "0"
+            self.assertFalse(should_compress(10_000_000))
+            os.environ["ODL_COMPRESS"] = "1"
+            os.environ["ODL_COMPRESS_THRESHOLD"] = "100"
+            self.assertTrue(should_compress(200))
+        finally:
+            if old is None:
+                os.environ.pop("ODL_COMPRESS", None)
+            else:
+                os.environ["ODL_COMPRESS"] = old
+            if old_t is None:
+                os.environ.pop("ODL_COMPRESS_THRESHOLD", None)
+            else:
+                os.environ["ODL_COMPRESS_THRESHOLD"] = old_t
+
+
+class CInteropTests(unittest.TestCase):
+    def test_python_reads_c_blob(self):
+        so = Path(ROOT) / "build" / "compress" / "libodl_compress.so"
+        if not so.is_file():
+            so = Path(ROOT) / "build" / "compress" / "libodl_compress.dylib"
+        if not so.is_file():
+            self.skipTest("libodl_compress not built")
+        import bridge.odl_compress as m
+        old_load = m._load_odl_so
+        os.environ["ODL_COMPRESS_LIB"] = str(so)
+        try:
+            src = bytes([i & 0x3F for i in range(80_000)])
+            wire = m.compress(src)
+            self.assertIsNotNone(wire)
+            m._load_odl_so = lambda: None
+            self.assertEqual(m.decompress(wire), src)
+        finally:
+            m._load_odl_so = old_load
+            os.environ.pop("ODL_COMPRESS_LIB", None)
+
+
+@unittest.skipIf(backend_name() == "none", "no LZ4 backend on this machine")
+class BridgeTests(unittest.TestCase):
+    def test_put_stores_odlc_get_roundtrips(self):
+        import socket
+        import threading
+        import numpy as np
+        from bridge.tb_bridge_server import TensorStore, handle_client
+        from bridge.tb_bridge_client import TBBridgeClient
+
+        store = TensorStore(max_bytes=8 << 20)
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(4)
+        port = srv.getsockname()[1]
+        stop = threading.Event()
+
+        def loop():
+            srv.settimeout(0.2)
+            while not stop.is_set():
+                try:
+                    client, addr = srv.accept()
+                except (socket.timeout, OSError):
+                    continue
+                handle_client(client, addr, store, False)
+
+        threading.Thread(target=loop, daemon=True).start()
+        old_t = os.environ.get("ODL_COMPRESS_THRESHOLD")
+        os.environ["ODL_COMPRESS_THRESHOLD"] = "1000"
+        try:
+            cli = TBBridgeClient("127.0.0.1", port, timeout=5)
+            x = np.zeros(40_000, dtype=np.float32)
+            x[:50] = np.arange(50)
+            cli.put("kv.0", x)
+            meta, data = store.get("kv.0")
+            self.assertTrue(looks_compressed(data))
+            self.assertLess(len(data), x.nbytes)
+            y = cli.get("kv.0")
+            np.testing.assert_array_equal(x, y)
+            viewed = store.view("kv.0")
+            np.testing.assert_array_equal(np.asarray(viewed), x)
+        finally:
+            stop.set()
+            srv.close()
+            if old_t is None:
+                os.environ.pop("ODL_COMPRESS_THRESHOLD", None)
+            else:
+                os.environ["ODL_COMPRESS_THRESHOLD"] = old_t
+
+
+if __name__ == "__main__":
+    print("lz4 backend:", backend_name())
+    result = unittest.main(verbosity=2, exit=False)
+    sys.exit(0 if result.result.wasSuccessful() else 1)

--- a/compress/third_party/lz4/README
+++ b/compress/third_party/lz4/README
@@ -1,0 +1,3 @@
+Vendored LZ4 v1.10.0 (`lz4.c`, `lz4.h`) from https://github.com/lz4/lz4
+BSD-2-Clause. Used for the portable ODLC lz4_block payload the Mac can
+decode. Do not replace with nvCOMP headers.

--- a/compress/third_party/lz4/lz4.c
+++ b/compress/third_party/lz4/lz4.c
@@ -1,0 +1,2829 @@
+/*
+   LZ4 - Fast LZ compression algorithm
+   Copyright (C) 2011-2023, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+    - LZ4 homepage : http://www.lz4.org
+    - LZ4 source repository : https://github.com/lz4/lz4
+*/
+
+/*-************************************
+*  Tuning parameters
+**************************************/
+/*
+ * LZ4_HEAPMODE :
+ * Select how stateless compression functions like `LZ4_compress_default()`
+ * allocate memory for their hash table,
+ * in memory stack (0:default, fastest), or in memory heap (1:requires malloc()).
+ */
+#ifndef LZ4_HEAPMODE
+#  define LZ4_HEAPMODE 0
+#endif
+
+/*
+ * LZ4_ACCELERATION_DEFAULT :
+ * Select "acceleration" for LZ4_compress_fast() when parameter value <= 0
+ */
+#define LZ4_ACCELERATION_DEFAULT 1
+/*
+ * LZ4_ACCELERATION_MAX :
+ * Any "acceleration" value higher than this threshold
+ * get treated as LZ4_ACCELERATION_MAX instead (fix #876)
+ */
+#define LZ4_ACCELERATION_MAX 65537
+
+
+/*-************************************
+*  CPU Feature Detection
+**************************************/
+/* LZ4_FORCE_MEMORY_ACCESS
+ * By default, access to unaligned memory is controlled by `memcpy()`, which is safe and portable.
+ * Unfortunately, on some target/compiler combinations, the generated assembly is sub-optimal.
+ * The below switch allow to select different access method for improved performance.
+ * Method 0 (default) : use `memcpy()`. Safe and portable.
+ * Method 1 : `__packed` statement. It depends on compiler extension (ie, not portable).
+ *            This method is safe if your compiler supports it, and *generally* as fast or faster than `memcpy`.
+ * Method 2 : direct access. This method is portable but violate C standard.
+ *            It can generate buggy code on targets which assembly generation depends on alignment.
+ *            But in some circumstances, it's the only known way to get the most performance (ie GCC + ARMv6)
+ * See https://fastcompression.blogspot.fr/2015/08/accessing-unaligned-memory.html for details.
+ * Prefer these methods in priority order (0 > 1 > 2)
+ */
+#ifndef LZ4_FORCE_MEMORY_ACCESS   /* can be defined externally */
+#  if defined(__GNUC__) && \
+  ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) \
+  || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
+#    define LZ4_FORCE_MEMORY_ACCESS 2
+#  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || defined(__GNUC__) || defined(_MSC_VER)
+#    define LZ4_FORCE_MEMORY_ACCESS 1
+#  endif
+#endif
+
+/*
+ * LZ4_FORCE_SW_BITCOUNT
+ * Define this parameter if your target system or compiler does not support hardware bit count
+ */
+#if defined(_MSC_VER) && defined(_WIN32_WCE)   /* Visual Studio for WinCE doesn't support Hardware bit count */
+#  undef  LZ4_FORCE_SW_BITCOUNT  /* avoid double def */
+#  define LZ4_FORCE_SW_BITCOUNT
+#endif
+
+
+
+/*-************************************
+*  Dependency
+**************************************/
+/*
+ * LZ4_SRC_INCLUDED:
+ * Amalgamation flag, whether lz4.c is included
+ */
+#ifndef LZ4_SRC_INCLUDED
+#  define LZ4_SRC_INCLUDED 1
+#endif
+
+#ifndef LZ4_DISABLE_DEPRECATE_WARNINGS
+#  define LZ4_DISABLE_DEPRECATE_WARNINGS /* due to LZ4_decompress_safe_withPrefix64k */
+#endif
+
+#ifndef LZ4_STATIC_LINKING_ONLY
+#  define LZ4_STATIC_LINKING_ONLY
+#endif
+#include "lz4.h"
+/* see also "memory routines" below */
+
+
+/*-************************************
+*  Compiler Options
+**************************************/
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)  /* Visual Studio 2005+ */
+#  include <intrin.h>               /* only present in VS2005+ */
+#  pragma warning(disable : 4127)   /* disable: C4127: conditional expression is constant */
+#  pragma warning(disable : 6237)   /* disable: C6237: conditional expression is always 0 */
+#  pragma warning(disable : 6239)   /* disable: C6239: (<non-zero constant> && <expression>) always evaluates to the result of <expression> */
+#  pragma warning(disable : 6240)   /* disable: C6240: (<expression> && <non-zero constant>) always evaluates to the result of <expression> */
+#  pragma warning(disable : 6326)   /* disable: C6326: Potential comparison of a constant with another constant */
+#endif  /* _MSC_VER */
+
+#ifndef LZ4_FORCE_INLINE
+#  if defined (_MSC_VER) && !defined (__clang__)    /* MSVC */
+#    define LZ4_FORCE_INLINE static __forceinline
+#  else
+#    if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+#      if defined (__GNUC__) || defined (__clang__)
+#        define LZ4_FORCE_INLINE static inline __attribute__((always_inline))
+#      else
+#        define LZ4_FORCE_INLINE static inline
+#      endif
+#    else
+#      define LZ4_FORCE_INLINE static
+#    endif /* __STDC_VERSION__ */
+#  endif  /* _MSC_VER */
+#endif /* LZ4_FORCE_INLINE */
+
+/* LZ4_FORCE_O2 and LZ4_FORCE_INLINE
+ * gcc on ppc64le generates an unrolled SIMDized loop for LZ4_wildCopy8,
+ * together with a simple 8-byte copy loop as a fall-back path.
+ * However, this optimization hurts the decompression speed by >30%,
+ * because the execution does not go to the optimized loop
+ * for typical compressible data, and all of the preamble checks
+ * before going to the fall-back path become useless overhead.
+ * This optimization happens only with the -O3 flag, and -O2 generates
+ * a simple 8-byte copy loop.
+ * With gcc on ppc64le, all of the LZ4_decompress_* and LZ4_wildCopy8
+ * functions are annotated with __attribute__((optimize("O2"))),
+ * and also LZ4_wildCopy8 is forcibly inlined, so that the O2 attribute
+ * of LZ4_wildCopy8 does not affect the compression speed.
+ */
+#if defined(__PPC64__) && defined(__LITTLE_ENDIAN__) && defined(__GNUC__) && !defined(__clang__)
+#  define LZ4_FORCE_O2  __attribute__((optimize("O2")))
+#  undef LZ4_FORCE_INLINE
+#  define LZ4_FORCE_INLINE  static __inline __attribute__((optimize("O2"),always_inline))
+#else
+#  define LZ4_FORCE_O2
+#endif
+
+#if (defined(__GNUC__) && (__GNUC__ >= 3)) || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) || defined(__clang__)
+#  define expect(expr,value)    (__builtin_expect ((expr),(value)) )
+#else
+#  define expect(expr,value)    (expr)
+#endif
+
+#ifndef likely
+#define likely(expr)     expect((expr) != 0, 1)
+#endif
+#ifndef unlikely
+#define unlikely(expr)   expect((expr) != 0, 0)
+#endif
+
+/* Should the alignment test prove unreliable, for some reason,
+ * it can be disabled by setting LZ4_ALIGN_TEST to 0 */
+#ifndef LZ4_ALIGN_TEST  /* can be externally provided */
+# define LZ4_ALIGN_TEST 1
+#endif
+
+
+/*-************************************
+*  Memory routines
+**************************************/
+
+/*! LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION :
+ *  Disable relatively high-level LZ4/HC functions that use dynamic memory
+ *  allocation functions (malloc(), calloc(), free()).
+ *
+ *  Note that this is a compile-time switch. And since it disables
+ *  public/stable LZ4 v1 API functions, we don't recommend using this
+ *  symbol to generate a library for distribution.
+ *
+ *  The following public functions are removed when this symbol is defined.
+ *  - lz4   : LZ4_createStream, LZ4_freeStream,
+ *            LZ4_createStreamDecode, LZ4_freeStreamDecode, LZ4_create (deprecated)
+ *  - lz4hc : LZ4_createStreamHC, LZ4_freeStreamHC,
+ *            LZ4_createHC (deprecated), LZ4_freeHC  (deprecated)
+ *  - lz4frame, lz4file : All LZ4F_* functions
+ */
+#if defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+#  define ALLOC(s)          lz4_error_memory_allocation_is_disabled
+#  define ALLOC_AND_ZERO(s) lz4_error_memory_allocation_is_disabled
+#  define FREEMEM(p)        lz4_error_memory_allocation_is_disabled
+#elif defined(LZ4_USER_MEMORY_FUNCTIONS)
+/* memory management functions can be customized by user project.
+ * Below functions must exist somewhere in the Project
+ * and be available at link time */
+void* LZ4_malloc(size_t s);
+void* LZ4_calloc(size_t n, size_t s);
+void  LZ4_free(void* p);
+# define ALLOC(s)          LZ4_malloc(s)
+# define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
+# define FREEMEM(p)        LZ4_free(p)
+#else
+# include <stdlib.h>   /* malloc, calloc, free */
+# define ALLOC(s)          malloc(s)
+# define ALLOC_AND_ZERO(s) calloc(1,s)
+# define FREEMEM(p)        free(p)
+#endif
+
+#if ! LZ4_FREESTANDING
+#  include <string.h>   /* memset, memcpy */
+#endif
+#if !defined(LZ4_memset)
+#  define LZ4_memset(p,v,s) memset((p),(v),(s))
+#endif
+#define MEM_INIT(p,v,s)   LZ4_memset((p),(v),(s))
+
+
+/*-************************************
+*  Common Constants
+**************************************/
+#define MINMATCH 4
+
+#define WILDCOPYLENGTH 8
+#define LASTLITERALS   5   /* see ../doc/lz4_Block_format.md#parsing-restrictions */
+#define MFLIMIT       12   /* see ../doc/lz4_Block_format.md#parsing-restrictions */
+#define MATCH_SAFEGUARD_DISTANCE  ((2*WILDCOPYLENGTH) - MINMATCH)   /* ensure it's possible to write 2 x wildcopyLength without overflowing output buffer */
+#define FASTLOOP_SAFE_DISTANCE 64
+static const int LZ4_minLength = (MFLIMIT+1);
+
+#define KB *(1 <<10)
+#define MB *(1 <<20)
+#define GB *(1U<<30)
+
+#define LZ4_DISTANCE_ABSOLUTE_MAX 65535
+#if (LZ4_DISTANCE_MAX > LZ4_DISTANCE_ABSOLUTE_MAX)   /* max supported by LZ4 format */
+#  error "LZ4_DISTANCE_MAX is too big : must be <= 65535"
+#endif
+
+#define ML_BITS  4
+#define ML_MASK  ((1U<<ML_BITS)-1)
+#define RUN_BITS (8-ML_BITS)
+#define RUN_MASK ((1U<<RUN_BITS)-1)
+
+
+/*-************************************
+*  Error detection
+**************************************/
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=1)
+#  include <assert.h>
+#else
+#  ifndef assert
+#    define assert(condition) ((void)0)
+#  endif
+#endif
+
+#define LZ4_STATIC_ASSERT(c)   { enum { LZ4_static_assert = 1/(int)(!!(c)) }; }   /* use after variable declarations */
+
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=2)
+#  include <stdio.h>
+   static int g_debuglog_enable = 1;
+#  define DEBUGLOG(l, ...) {                          \
+        if ((g_debuglog_enable) && (l<=LZ4_DEBUG)) {  \
+            fprintf(stderr, __FILE__  " %i: ", __LINE__); \
+            fprintf(stderr, __VA_ARGS__);             \
+            fprintf(stderr, " \n");                   \
+    }   }
+#else
+#  define DEBUGLOG(l, ...) {}    /* disabled */
+#endif
+
+static int LZ4_isAligned(const void* ptr, size_t alignment)
+{
+    return ((size_t)ptr & (alignment -1)) == 0;
+}
+
+
+/*-************************************
+*  Types
+**************************************/
+#include <limits.h>
+#if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+# include <stdint.h>
+  typedef  uint8_t BYTE;
+  typedef uint16_t U16;
+  typedef uint32_t U32;
+  typedef  int32_t S32;
+  typedef uint64_t U64;
+  typedef uintptr_t uptrval;
+#else
+# if UINT_MAX != 4294967295UL
+#   error "LZ4 code (when not C++ or C99) assumes that sizeof(int) == 4"
+# endif
+  typedef unsigned char       BYTE;
+  typedef unsigned short      U16;
+  typedef unsigned int        U32;
+  typedef   signed int        S32;
+  typedef unsigned long long  U64;
+  typedef size_t              uptrval;   /* generally true, except OpenVMS-64 */
+#endif
+
+#if defined(__x86_64__)
+  typedef U64    reg_t;   /* 64-bits in x32 mode */
+#else
+  typedef size_t reg_t;   /* 32-bits in x32 mode */
+#endif
+
+typedef enum {
+    notLimited = 0,
+    limitedOutput = 1,
+    fillOutput = 2
+} limitedOutput_directive;
+
+
+/*-************************************
+*  Reading and writing into memory
+**************************************/
+
+/**
+ * LZ4 relies on memcpy with a constant size being inlined. In freestanding
+ * environments, the compiler can't assume the implementation of memcpy() is
+ * standard compliant, so it can't apply its specialized memcpy() inlining
+ * logic. When possible, use __builtin_memcpy() to tell the compiler to analyze
+ * memcpy() as if it were standard compliant, so it can inline it in freestanding
+ * environments. This is needed when decompressing the Linux Kernel, for example.
+ */
+#if !defined(LZ4_memcpy)
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LZ4_memcpy(dst, src, size) __builtin_memcpy(dst, src, size)
+#  else
+#    define LZ4_memcpy(dst, src, size) memcpy(dst, src, size)
+#  endif
+#endif
+
+#if !defined(LZ4_memmove)
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LZ4_memmove __builtin_memmove
+#  else
+#    define LZ4_memmove memmove
+#  endif
+#endif
+
+static unsigned LZ4_isLittleEndian(void)
+{
+    const union { U32 u; BYTE c[4]; } one = { 1 };   /* don't use static : performance detrimental */
+    return one.c[0];
+}
+
+#if defined(__GNUC__) || defined(__INTEL_COMPILER)
+#define LZ4_PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#elif defined(_MSC_VER)
+#define LZ4_PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop))
+#endif
+
+#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==2)
+/* lie to the compiler about data alignment; use with caution */
+
+static U16 LZ4_read16(const void* memPtr) { return *(const U16*) memPtr; }
+static U32 LZ4_read32(const void* memPtr) { return *(const U32*) memPtr; }
+static reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; }
+
+static void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
+static void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
+
+#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
+/* currently only defined for gcc and icc */
+LZ4_PACK(typedef struct { U16 u16; }) LZ4_unalign16;
+LZ4_PACK(typedef struct { U32 u32; }) LZ4_unalign32;
+LZ4_PACK(typedef struct { reg_t uArch; }) LZ4_unalignST;
+
+static U16 LZ4_read16(const void* ptr) { return ((const LZ4_unalign16*)ptr)->u16; }
+static U32 LZ4_read32(const void* ptr) { return ((const LZ4_unalign32*)ptr)->u32; }
+static reg_t LZ4_read_ARCH(const void* ptr) { return ((const LZ4_unalignST*)ptr)->uArch; }
+
+static void LZ4_write16(void* memPtr, U16 value) { ((LZ4_unalign16*)memPtr)->u16 = value; }
+static void LZ4_write32(void* memPtr, U32 value) { ((LZ4_unalign32*)memPtr)->u32 = value; }
+
+#else  /* safe and portable access using memcpy() */
+
+static U16 LZ4_read16(const void* memPtr)
+{
+    U16 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+}
+
+static U32 LZ4_read32(const void* memPtr)
+{
+    U32 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+}
+
+static reg_t LZ4_read_ARCH(const void* memPtr)
+{
+    reg_t val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+}
+
+static void LZ4_write16(void* memPtr, U16 value)
+{
+    LZ4_memcpy(memPtr, &value, sizeof(value));
+}
+
+static void LZ4_write32(void* memPtr, U32 value)
+{
+    LZ4_memcpy(memPtr, &value, sizeof(value));
+}
+
+#endif /* LZ4_FORCE_MEMORY_ACCESS */
+
+
+static U16 LZ4_readLE16(const void* memPtr)
+{
+    if (LZ4_isLittleEndian()) {
+        return LZ4_read16(memPtr);
+    } else {
+        const BYTE* p = (const BYTE*)memPtr;
+        return (U16)((U16)p[0] | (p[1]<<8));
+    }
+}
+
+#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
+static U32 LZ4_readLE32(const void* memPtr)
+{
+    if (LZ4_isLittleEndian()) {
+        return LZ4_read32(memPtr);
+    } else {
+        const BYTE* p = (const BYTE*)memPtr;
+        return (U32)p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24);
+    }
+}
+#endif
+
+static void LZ4_writeLE16(void* memPtr, U16 value)
+{
+    if (LZ4_isLittleEndian()) {
+        LZ4_write16(memPtr, value);
+    } else {
+        BYTE* p = (BYTE*)memPtr;
+        p[0] = (BYTE) value;
+        p[1] = (BYTE)(value>>8);
+    }
+}
+
+/* customized variant of memcpy, which can overwrite up to 8 bytes beyond dstEnd */
+LZ4_FORCE_INLINE
+void LZ4_wildCopy8(void* dstPtr, const void* srcPtr, void* dstEnd)
+{
+    BYTE* d = (BYTE*)dstPtr;
+    const BYTE* s = (const BYTE*)srcPtr;
+    BYTE* const e = (BYTE*)dstEnd;
+
+    do { LZ4_memcpy(d,s,8); d+=8; s+=8; } while (d<e);
+}
+
+static const unsigned inc32table[8] = {0, 1, 2,  1,  0,  4, 4, 4};
+static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
+
+
+#ifndef LZ4_FAST_DEC_LOOP
+#  if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
+#    define LZ4_FAST_DEC_LOOP 1
+#  elif defined(__aarch64__) && defined(__APPLE__)
+#    define LZ4_FAST_DEC_LOOP 1
+#  elif defined(__aarch64__) && !defined(__clang__)
+     /* On non-Apple aarch64, we disable this optimization for clang because
+      * on certain mobile chipsets, performance is reduced with clang. For
+      * more information refer to https://github.com/lz4/lz4/pull/707 */
+#    define LZ4_FAST_DEC_LOOP 1
+#  else
+#    define LZ4_FAST_DEC_LOOP 0
+#  endif
+#endif
+
+#if LZ4_FAST_DEC_LOOP
+
+LZ4_FORCE_INLINE void
+LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
+{
+    assert(srcPtr + offset == dstPtr);
+    if (offset < 8) {
+        LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
+        dstPtr[0] = srcPtr[0];
+        dstPtr[1] = srcPtr[1];
+        dstPtr[2] = srcPtr[2];
+        dstPtr[3] = srcPtr[3];
+        srcPtr += inc32table[offset];
+        LZ4_memcpy(dstPtr+4, srcPtr, 4);
+        srcPtr -= dec64table[offset];
+        dstPtr += 8;
+    } else {
+        LZ4_memcpy(dstPtr, srcPtr, 8);
+        dstPtr += 8;
+        srcPtr += 8;
+    }
+
+    LZ4_wildCopy8(dstPtr, srcPtr, dstEnd);
+}
+
+/* customized variant of memcpy, which can overwrite up to 32 bytes beyond dstEnd
+ * this version copies two times 16 bytes (instead of one time 32 bytes)
+ * because it must be compatible with offsets >= 16. */
+LZ4_FORCE_INLINE void
+LZ4_wildCopy32(void* dstPtr, const void* srcPtr, void* dstEnd)
+{
+    BYTE* d = (BYTE*)dstPtr;
+    const BYTE* s = (const BYTE*)srcPtr;
+    BYTE* const e = (BYTE*)dstEnd;
+
+    do { LZ4_memcpy(d,s,16); LZ4_memcpy(d+16,s+16,16); d+=32; s+=32; } while (d<e);
+}
+
+/* LZ4_memcpy_using_offset()  presumes :
+ * - dstEnd >= dstPtr + MINMATCH
+ * - there is at least 12 bytes available to write after dstEnd */
+LZ4_FORCE_INLINE void
+LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
+{
+    BYTE v[8];
+
+    assert(dstEnd >= dstPtr + MINMATCH);
+
+    switch(offset) {
+    case 1:
+        MEM_INIT(v, *srcPtr, 8);
+        break;
+    case 2:
+        LZ4_memcpy(v, srcPtr, 2);
+        LZ4_memcpy(&v[2], srcPtr, 2);
+#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
+#  pragma warning(push)
+#  pragma warning(disable : 6385) /* warning C6385: Reading invalid data from 'v'. */
+#endif
+        LZ4_memcpy(&v[4], v, 4);
+#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
+#  pragma warning(pop)
+#endif
+        break;
+    case 4:
+        LZ4_memcpy(v, srcPtr, 4);
+        LZ4_memcpy(&v[4], srcPtr, 4);
+        break;
+    default:
+        LZ4_memcpy_using_offset_base(dstPtr, srcPtr, dstEnd, offset);
+        return;
+    }
+
+    LZ4_memcpy(dstPtr, v, 8);
+    dstPtr += 8;
+    while (dstPtr < dstEnd) {
+        LZ4_memcpy(dstPtr, v, 8);
+        dstPtr += 8;
+    }
+}
+#endif
+
+
+/*-************************************
+*  Common functions
+**************************************/
+static unsigned LZ4_NbCommonBytes (reg_t val)
+{
+    assert(val != 0);
+    if (LZ4_isLittleEndian()) {
+        if (sizeof(val) == 8) {
+#       if defined(_MSC_VER) && (_MSC_VER >= 1800) && (defined(_M_AMD64) && !defined(_M_ARM64EC)) && !defined(LZ4_FORCE_SW_BITCOUNT)
+/*-*************************************************************************************************
+* ARM64EC is a Microsoft-designed ARM64 ABI compatible with AMD64 applications on ARM64 Windows 11.
+* The ARM64EC ABI does not support AVX/AVX2/AVX512 instructions, nor their relevant intrinsics
+* including _tzcnt_u64. Therefore, we need to neuter the _tzcnt_u64 code path for ARM64EC.
+****************************************************************************************************/
+#         if defined(__clang__) && (__clang_major__ < 10)
+            /* Avoid undefined clang-cl intrinsics issue.
+             * See https://github.com/lz4/lz4/pull/1017 for details. */
+            return (unsigned)__builtin_ia32_tzcnt_u64(val) >> 3;
+#         else
+            /* x64 CPUS without BMI support interpret `TZCNT` as `REP BSF` */
+            return (unsigned)_tzcnt_u64(val) >> 3;
+#         endif
+#       elif defined(_MSC_VER) && defined(_WIN64) && !defined(LZ4_FORCE_SW_BITCOUNT)
+            unsigned long r = 0;
+            _BitScanForward64(&r, (U64)val);
+            return (unsigned)r >> 3;
+#       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+            return (unsigned)__builtin_ctzll((U64)val) >> 3;
+#       else
+            const U64 m = 0x0101010101010101ULL;
+            val ^= val - 1;
+            return (unsigned)(((U64)((val & (m - 1)) * m)) >> 56);
+#       endif
+        } else /* 32 bits */ {
+#       if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
+            unsigned long r;
+            _BitScanForward(&r, (U32)val);
+            return (unsigned)r >> 3;
+#       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
+            return (unsigned)__builtin_ctz((U32)val) >> 3;
+#       else
+            const U32 m = 0x01010101;
+            return (unsigned)((((val - 1) ^ val) & (m - 1)) * m) >> 24;
+#       endif
+        }
+    } else   /* Big Endian CPU */ {
+        if (sizeof(val)==8) {
+#       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
+            return (unsigned)__builtin_clzll((U64)val) >> 3;
+#       else
+#if 1
+            /* this method is probably faster,
+             * but adds a 128 bytes lookup table */
+            static const unsigned char ctz7_tab[128] = {
+                7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+            };
+            U64 const mask = 0x0101010101010101ULL;
+            U64 const t = (((val >> 8) - mask) | val) & mask;
+            return ctz7_tab[(t * 0x0080402010080402ULL) >> 57];
+#else
+            /* this method doesn't consume memory space like the previous one,
+             * but it contains several branches,
+             * that may end up slowing execution */
+            static const U32 by32 = sizeof(val)*4;  /* 32 on 64 bits (goal), 16 on 32 bits.
+            Just to avoid some static analyzer complaining about shift by 32 on 32-bits target.
+            Note that this code path is never triggered in 32-bits mode. */
+            unsigned r;
+            if (!(val>>by32)) { r=4; } else { r=0; val>>=by32; }
+            if (!(val>>16)) { r+=2; val>>=8; } else { val>>=24; }
+            r += (!val);
+            return r;
+#endif
+#       endif
+        } else /* 32 bits */ {
+#       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
+                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+            return (unsigned)__builtin_clz((U32)val) >> 3;
+#       else
+            val >>= 8;
+            val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) |
+              (val + 0x00FF0000)) >> 24;
+            return (unsigned)val ^ 3;
+#       endif
+        }
+    }
+}
+
+
+#define STEPSIZE sizeof(reg_t)
+LZ4_FORCE_INLINE
+unsigned LZ4_count(const BYTE* pIn, const BYTE* pMatch, const BYTE* pInLimit)
+{
+    const BYTE* const pStart = pIn;
+
+    if (likely(pIn < pInLimit-(STEPSIZE-1))) {
+        reg_t const diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
+        if (!diff) {
+            pIn+=STEPSIZE; pMatch+=STEPSIZE;
+        } else {
+            return LZ4_NbCommonBytes(diff);
+    }   }
+
+    while (likely(pIn < pInLimit-(STEPSIZE-1))) {
+        reg_t const diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
+        if (!diff) { pIn+=STEPSIZE; pMatch+=STEPSIZE; continue; }
+        pIn += LZ4_NbCommonBytes(diff);
+        return (unsigned)(pIn - pStart);
+    }
+
+    if ((STEPSIZE==8) && (pIn<(pInLimit-3)) && (LZ4_read32(pMatch) == LZ4_read32(pIn))) { pIn+=4; pMatch+=4; }
+    if ((pIn<(pInLimit-1)) && (LZ4_read16(pMatch) == LZ4_read16(pIn))) { pIn+=2; pMatch+=2; }
+    if ((pIn<pInLimit) && (*pMatch == *pIn)) pIn++;
+    return (unsigned)(pIn - pStart);
+}
+
+
+#ifndef LZ4_COMMONDEFS_ONLY
+/*-************************************
+*  Local Constants
+**************************************/
+static const int LZ4_64Klimit = ((64 KB) + (MFLIMIT-1));
+static const U32 LZ4_skipTrigger = 6;  /* Increase this value ==> compression run slower on incompressible data */
+
+
+/*-************************************
+*  Local Structures and types
+**************************************/
+typedef enum { clearedTable = 0, byPtr, byU32, byU16 } tableType_t;
+
+/**
+ * This enum distinguishes several different modes of accessing previous
+ * content in the stream.
+ *
+ * - noDict        : There is no preceding content.
+ * - withPrefix64k : Table entries up to ctx->dictSize before the current blob
+ *                   blob being compressed are valid and refer to the preceding
+ *                   content (of length ctx->dictSize), which is available
+ *                   contiguously preceding in memory the content currently
+ *                   being compressed.
+ * - usingExtDict  : Like withPrefix64k, but the preceding content is somewhere
+ *                   else in memory, starting at ctx->dictionary with length
+ *                   ctx->dictSize.
+ * - usingDictCtx  : Everything concerning the preceding content is
+ *                   in a separate context, pointed to by ctx->dictCtx.
+ *                   ctx->dictionary, ctx->dictSize, and table entries
+ *                   in the current context that refer to positions
+ *                   preceding the beginning of the current compression are
+ *                   ignored. Instead, ctx->dictCtx->dictionary and ctx->dictCtx
+ *                   ->dictSize describe the location and size of the preceding
+ *                   content, and matches are found by looking in the ctx
+ *                   ->dictCtx->hashTable.
+ */
+typedef enum { noDict = 0, withPrefix64k, usingExtDict, usingDictCtx } dict_directive;
+typedef enum { noDictIssue = 0, dictSmall } dictIssue_directive;
+
+
+/*-************************************
+*  Local Utils
+**************************************/
+int LZ4_versionNumber (void) { return LZ4_VERSION_NUMBER; }
+const char* LZ4_versionString(void) { return LZ4_VERSION_STRING; }
+int LZ4_compressBound(int isize)  { return LZ4_COMPRESSBOUND(isize); }
+int LZ4_sizeofState(void) { return sizeof(LZ4_stream_t); }
+
+
+/*-****************************************
+*  Internal Definitions, used only in Tests
+*******************************************/
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize);
+
+int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
+                                     int compressedSize, int maxOutputSize,
+                                     const void* dictStart, size_t dictSize);
+int LZ4_decompress_safe_partial_forceExtDict(const char* source, char* dest,
+                                     int compressedSize, int targetOutputSize, int dstCapacity,
+                                     const void* dictStart, size_t dictSize);
+#if defined (__cplusplus)
+}
+#endif
+
+/*-******************************
+*  Compression functions
+********************************/
+LZ4_FORCE_INLINE U32 LZ4_hash4(U32 sequence, tableType_t const tableType)
+{
+    if (tableType == byU16)
+        return ((sequence * 2654435761U) >> ((MINMATCH*8)-(LZ4_HASHLOG+1)));
+    else
+        return ((sequence * 2654435761U) >> ((MINMATCH*8)-LZ4_HASHLOG));
+}
+
+LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
+{
+    const U32 hashLog = (tableType == byU16) ? LZ4_HASHLOG+1 : LZ4_HASHLOG;
+    if (LZ4_isLittleEndian()) {
+        const U64 prime5bytes = 889523592379ULL;
+        return (U32)(((sequence << 24) * prime5bytes) >> (64 - hashLog));
+    } else {
+        const U64 prime8bytes = 11400714785074694791ULL;
+        return (U32)(((sequence >> 24) * prime8bytes) >> (64 - hashLog));
+    }
+}
+
+LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tableType)
+{
+    if ((sizeof(reg_t)==8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
+
+#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
+    return LZ4_hash4(LZ4_readLE32(p), tableType);
+#else
+    return LZ4_hash4(LZ4_read32(p), tableType);
+#endif
+}
+
+LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)
+{
+    switch (tableType)
+    {
+    default: /* fallthrough */
+    case clearedTable: { /* illegal! */ assert(0); return; }
+    case byPtr: { const BYTE** hashTable = (const BYTE**)tableBase; hashTable[h] = NULL; return; }
+    case byU32: { U32* hashTable = (U32*) tableBase; hashTable[h] = 0; return; }
+    case byU16: { U16* hashTable = (U16*) tableBase; hashTable[h] = 0; return; }
+    }
+}
+
+LZ4_FORCE_INLINE void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, tableType_t const tableType)
+{
+    switch (tableType)
+    {
+    default: /* fallthrough */
+    case clearedTable: /* fallthrough */
+    case byPtr: { /* illegal! */ assert(0); return; }
+    case byU32: { U32* hashTable = (U32*) tableBase; hashTable[h] = idx; return; }
+    case byU16: { U16* hashTable = (U16*) tableBase; assert(idx < 65536); hashTable[h] = (U16)idx; return; }
+    }
+}
+
+/* LZ4_putPosition*() : only used in byPtr mode */
+LZ4_FORCE_INLINE void LZ4_putPositionOnHash(const BYTE* p, U32 h,
+                                  void* tableBase, tableType_t const tableType)
+{
+    const BYTE** const hashTable = (const BYTE**)tableBase;
+    assert(tableType == byPtr); (void)tableType;
+    hashTable[h] = p;
+}
+
+LZ4_FORCE_INLINE void LZ4_putPosition(const BYTE* p, void* tableBase, tableType_t tableType)
+{
+    U32 const h = LZ4_hashPosition(p, tableType);
+    LZ4_putPositionOnHash(p, h, tableBase, tableType);
+}
+
+/* LZ4_getIndexOnHash() :
+ * Index of match position registered in hash table.
+ * hash position must be calculated by using base+index, or dictBase+index.
+ * Assumption 1 : only valid if tableType == byU32 or byU16.
+ * Assumption 2 : h is presumed valid (within limits of hash table)
+ */
+LZ4_FORCE_INLINE U32 LZ4_getIndexOnHash(U32 h, const void* tableBase, tableType_t tableType)
+{
+    LZ4_STATIC_ASSERT(LZ4_MEMORY_USAGE > 2);
+    if (tableType == byU32) {
+        const U32* const hashTable = (const U32*) tableBase;
+        assert(h < (1U << (LZ4_MEMORY_USAGE-2)));
+        return hashTable[h];
+    }
+    if (tableType == byU16) {
+        const U16* const hashTable = (const U16*) tableBase;
+        assert(h < (1U << (LZ4_MEMORY_USAGE-1)));
+        return hashTable[h];
+    }
+    assert(0); return 0;  /* forbidden case */
+}
+
+static const BYTE* LZ4_getPositionOnHash(U32 h, const void* tableBase, tableType_t tableType)
+{
+    assert(tableType == byPtr); (void)tableType;
+    { const BYTE* const* hashTable = (const BYTE* const*) tableBase; return hashTable[h]; }
+}
+
+LZ4_FORCE_INLINE const BYTE*
+LZ4_getPosition(const BYTE* p,
+                const void* tableBase, tableType_t tableType)
+{
+    U32 const h = LZ4_hashPosition(p, tableType);
+    return LZ4_getPositionOnHash(h, tableBase, tableType);
+}
+
+LZ4_FORCE_INLINE void
+LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
+           const int inputSize,
+           const tableType_t tableType) {
+    /* If the table hasn't been used, it's guaranteed to be zeroed out, and is
+     * therefore safe to use no matter what mode we're in. Otherwise, we figure
+     * out if it's safe to leave as is or whether it needs to be reset.
+     */
+    if ((tableType_t)cctx->tableType != clearedTable) {
+        assert(inputSize >= 0);
+        if ((tableType_t)cctx->tableType != tableType
+          || ((tableType == byU16) && cctx->currentOffset + (unsigned)inputSize >= 0xFFFFU)
+          || ((tableType == byU32) && cctx->currentOffset > 1 GB)
+          || tableType == byPtr
+          || inputSize >= 4 KB)
+        {
+            DEBUGLOG(4, "LZ4_prepareTable: Resetting table in %p", cctx);
+            MEM_INIT(cctx->hashTable, 0, LZ4_HASHTABLESIZE);
+            cctx->currentOffset = 0;
+            cctx->tableType = (U32)clearedTable;
+        } else {
+            DEBUGLOG(4, "LZ4_prepareTable: Re-use hash table (no reset)");
+        }
+    }
+
+    /* Adding a gap, so all previous entries are > LZ4_DISTANCE_MAX back,
+     * is faster than compressing without a gap.
+     * However, compressing with currentOffset == 0 is faster still,
+     * so we preserve that case.
+     */
+    if (cctx->currentOffset != 0 && tableType == byU32) {
+        DEBUGLOG(5, "LZ4_prepareTable: adding 64KB to currentOffset");
+        cctx->currentOffset += 64 KB;
+    }
+
+    /* Finally, clear history */
+    cctx->dictCtx = NULL;
+    cctx->dictionary = NULL;
+    cctx->dictSize = 0;
+}
+
+/** LZ4_compress_generic_validated() :
+ *  inlined, to ensure branches are decided at compilation time.
+ *  The following conditions are presumed already validated:
+ *  - source != NULL
+ *  - inputSize > 0
+ */
+LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
+                 LZ4_stream_t_internal* const cctx,
+                 const char* const source,
+                 char* const dest,
+                 const int inputSize,
+                 int*  inputConsumed, /* only written when outputDirective == fillOutput */
+                 const int maxOutputSize,
+                 const limitedOutput_directive outputDirective,
+                 const tableType_t tableType,
+                 const dict_directive dictDirective,
+                 const dictIssue_directive dictIssue,
+                 const int acceleration)
+{
+    int result;
+    const BYTE* ip = (const BYTE*)source;
+
+    U32 const startIndex = cctx->currentOffset;
+    const BYTE* base = (const BYTE*)source - startIndex;
+    const BYTE* lowLimit;
+
+    const LZ4_stream_t_internal* dictCtx = (const LZ4_stream_t_internal*) cctx->dictCtx;
+    const BYTE* const dictionary =
+        dictDirective == usingDictCtx ? dictCtx->dictionary : cctx->dictionary;
+    const U32 dictSize =
+        dictDirective == usingDictCtx ? dictCtx->dictSize : cctx->dictSize;
+    const U32 dictDelta =
+        (dictDirective == usingDictCtx) ? startIndex - dictCtx->currentOffset : 0;   /* make indexes in dictCtx comparable with indexes in current context */
+
+    int const maybe_extMem = (dictDirective == usingExtDict) || (dictDirective == usingDictCtx);
+    U32 const prefixIdxLimit = startIndex - dictSize;   /* used when dictDirective == dictSmall */
+    const BYTE* const dictEnd = dictionary ? dictionary + dictSize : dictionary;
+    const BYTE* anchor = (const BYTE*) source;
+    const BYTE* const iend = ip + inputSize;
+    const BYTE* const mflimitPlusOne = iend - MFLIMIT + 1;
+    const BYTE* const matchlimit = iend - LASTLITERALS;
+
+    /* the dictCtx currentOffset is indexed on the start of the dictionary,
+     * while a dictionary in the current context precedes the currentOffset */
+    const BYTE* dictBase = (dictionary == NULL) ? NULL :
+                           (dictDirective == usingDictCtx) ?
+                            dictionary + dictSize - dictCtx->currentOffset :
+                            dictionary + dictSize - startIndex;
+
+    BYTE* op = (BYTE*) dest;
+    BYTE* const olimit = op + maxOutputSize;
+
+    U32 offset = 0;
+    U32 forwardH;
+
+    DEBUGLOG(5, "LZ4_compress_generic_validated: srcSize=%i, tableType=%u", inputSize, tableType);
+    assert(ip != NULL);
+    if (tableType == byU16) assert(inputSize<LZ4_64Klimit);  /* Size too large (not within 64K limit) */
+    if (tableType == byPtr) assert(dictDirective==noDict);   /* only supported use case with byPtr */
+    /* If init conditions are not met, we don't have to mark stream
+     * as having dirty context, since no action was taken yet */
+    if (outputDirective == fillOutput && maxOutputSize < 1) { return 0; } /* Impossible to store anything */
+    assert(acceleration >= 1);
+
+    lowLimit = (const BYTE*)source - (dictDirective == withPrefix64k ? dictSize : 0);
+
+    /* Update context state */
+    if (dictDirective == usingDictCtx) {
+        /* Subsequent linked blocks can't use the dictionary. */
+        /* Instead, they use the block we just compressed. */
+        cctx->dictCtx = NULL;
+        cctx->dictSize = (U32)inputSize;
+    } else {
+        cctx->dictSize += (U32)inputSize;
+    }
+    cctx->currentOffset += (U32)inputSize;
+    cctx->tableType = (U32)tableType;
+
+    if (inputSize<LZ4_minLength) goto _last_literals;        /* Input too small, no compression (all literals) */
+
+    /* First Byte */
+    {   U32 const h = LZ4_hashPosition(ip, tableType);
+        if (tableType == byPtr) {
+            LZ4_putPositionOnHash(ip, h, cctx->hashTable, byPtr);
+        } else {
+            LZ4_putIndexOnHash(startIndex, h, cctx->hashTable, tableType);
+    }   }
+    ip++; forwardH = LZ4_hashPosition(ip, tableType);
+
+    /* Main Loop */
+    for ( ; ; ) {
+        const BYTE* match;
+        BYTE* token;
+        const BYTE* filledIp;
+
+        /* Find a match */
+        if (tableType == byPtr) {
+            const BYTE* forwardIp = ip;
+            int step = 1;
+            int searchMatchNb = acceleration << LZ4_skipTrigger;
+            do {
+                U32 const h = forwardH;
+                ip = forwardIp;
+                forwardIp += step;
+                step = (searchMatchNb++ >> LZ4_skipTrigger);
+
+                if (unlikely(forwardIp > mflimitPlusOne)) goto _last_literals;
+                assert(ip < mflimitPlusOne);
+
+                match = LZ4_getPositionOnHash(h, cctx->hashTable, tableType);
+                forwardH = LZ4_hashPosition(forwardIp, tableType);
+                LZ4_putPositionOnHash(ip, h, cctx->hashTable, tableType);
+
+            } while ( (match+LZ4_DISTANCE_MAX < ip)
+                   || (LZ4_read32(match) != LZ4_read32(ip)) );
+
+        } else {   /* byU32, byU16 */
+
+            const BYTE* forwardIp = ip;
+            int step = 1;
+            int searchMatchNb = acceleration << LZ4_skipTrigger;
+            do {
+                U32 const h = forwardH;
+                U32 const current = (U32)(forwardIp - base);
+                U32 matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
+                assert(matchIndex <= current);
+                assert(forwardIp - base < (ptrdiff_t)(2 GB - 1));
+                ip = forwardIp;
+                forwardIp += step;
+                step = (searchMatchNb++ >> LZ4_skipTrigger);
+
+                if (unlikely(forwardIp > mflimitPlusOne)) goto _last_literals;
+                assert(ip < mflimitPlusOne);
+
+                if (dictDirective == usingDictCtx) {
+                    if (matchIndex < startIndex) {
+                        /* there was no match, try the dictionary */
+                        assert(tableType == byU32);
+                        matchIndex = LZ4_getIndexOnHash(h, dictCtx->hashTable, byU32);
+                        match = dictBase + matchIndex;
+                        matchIndex += dictDelta;   /* make dictCtx index comparable with current context */
+                        lowLimit = dictionary;
+                    } else {
+                        match = base + matchIndex;
+                        lowLimit = (const BYTE*)source;
+                    }
+                } else if (dictDirective == usingExtDict) {
+                    if (matchIndex < startIndex) {
+                        DEBUGLOG(7, "extDict candidate: matchIndex=%5u  <  startIndex=%5u", matchIndex, startIndex);
+                        assert(startIndex - matchIndex >= MINMATCH);
+                        assert(dictBase);
+                        match = dictBase + matchIndex;
+                        lowLimit = dictionary;
+                    } else {
+                        match = base + matchIndex;
+                        lowLimit = (const BYTE*)source;
+                    }
+                } else {   /* single continuous memory segment */
+                    match = base + matchIndex;
+                }
+                forwardH = LZ4_hashPosition(forwardIp, tableType);
+                LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
+
+                DEBUGLOG(7, "candidate at pos=%u  (offset=%u \n", matchIndex, current - matchIndex);
+                if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) { continue; }    /* match outside of valid area */
+                assert(matchIndex < current);
+                if ( ((tableType != byU16) || (LZ4_DISTANCE_MAX < LZ4_DISTANCE_ABSOLUTE_MAX))
+                  && (matchIndex+LZ4_DISTANCE_MAX < current)) {
+                    continue;
+                } /* too far */
+                assert((current - matchIndex) <= LZ4_DISTANCE_MAX);  /* match now expected within distance */
+
+                if (LZ4_read32(match) == LZ4_read32(ip)) {
+                    if (maybe_extMem) offset = current - matchIndex;
+                    break;   /* match found */
+                }
+
+            } while(1);
+        }
+
+        /* Catch up */
+        filledIp = ip;
+        assert(ip > anchor); /* this is always true as ip has been advanced before entering the main loop */
+        if ((match > lowLimit) && unlikely(ip[-1] == match[-1])) {
+            do { ip--; match--; } while (((ip > anchor) & (match > lowLimit)) && (unlikely(ip[-1] == match[-1])));
+        }
+
+        /* Encode Literals */
+        {   unsigned const litLength = (unsigned)(ip - anchor);
+            token = op++;
+            if ((outputDirective == limitedOutput) &&  /* Check output buffer overflow */
+                (unlikely(op + litLength + (2 + 1 + LASTLITERALS) + (litLength/255) > olimit)) ) {
+                return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+            }
+            if ((outputDirective == fillOutput) &&
+                (unlikely(op + (litLength+240)/255 /* litlen */ + litLength /* literals */ + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ > olimit))) {
+                op--;
+                goto _last_literals;
+            }
+            if (litLength >= RUN_MASK) {
+                unsigned len = litLength - RUN_MASK;
+                *token = (RUN_MASK<<ML_BITS);
+                for(; len >= 255 ; len-=255) *op++ = 255;
+                *op++ = (BYTE)len;
+            }
+            else *token = (BYTE)(litLength<<ML_BITS);
+
+            /* Copy Literals */
+            LZ4_wildCopy8(op, anchor, op+litLength);
+            op+=litLength;
+            DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i",
+                        (int)(anchor-(const BYTE*)source), litLength, (int)(ip-(const BYTE*)source));
+        }
+
+_next_match:
+        /* at this stage, the following variables must be correctly set :
+         * - ip : at start of LZ operation
+         * - match : at start of previous pattern occurrence; can be within current prefix, or within extDict
+         * - offset : if maybe_ext_memSegment==1 (constant)
+         * - lowLimit : must be == dictionary to mean "match is within extDict"; must be == source otherwise
+         * - token and *token : position to write 4-bits for match length; higher 4-bits for literal length supposed already written
+         */
+
+        if ((outputDirective == fillOutput) &&
+            (op + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ > olimit)) {
+            /* the match was too close to the end, rewind and go to last literals */
+            op = token;
+            goto _last_literals;
+        }
+
+        /* Encode Offset */
+        if (maybe_extMem) {   /* static test */
+            DEBUGLOG(6, "             with offset=%u  (ext if > %i)", offset, (int)(ip - (const BYTE*)source));
+            assert(offset <= LZ4_DISTANCE_MAX && offset > 0);
+            LZ4_writeLE16(op, (U16)offset); op+=2;
+        } else  {
+            DEBUGLOG(6, "             with offset=%u  (same segment)", (U32)(ip - match));
+            assert(ip-match <= LZ4_DISTANCE_MAX);
+            LZ4_writeLE16(op, (U16)(ip - match)); op+=2;
+        }
+
+        /* Encode MatchLength */
+        {   unsigned matchCode;
+
+            if ( (dictDirective==usingExtDict || dictDirective==usingDictCtx)
+              && (lowLimit==dictionary) /* match within extDict */ ) {
+                const BYTE* limit = ip + (dictEnd-match);
+                assert(dictEnd > match);
+                if (limit > matchlimit) limit = matchlimit;
+                matchCode = LZ4_count(ip+MINMATCH, match+MINMATCH, limit);
+                ip += (size_t)matchCode + MINMATCH;
+                if (ip==limit) {
+                    unsigned const more = LZ4_count(limit, (const BYTE*)source, matchlimit);
+                    matchCode += more;
+                    ip += more;
+                }
+                DEBUGLOG(6, "             with matchLength=%u starting in extDict", matchCode+MINMATCH);
+            } else {
+                matchCode = LZ4_count(ip+MINMATCH, match+MINMATCH, matchlimit);
+                ip += (size_t)matchCode + MINMATCH;
+                DEBUGLOG(6, "             with matchLength=%u", matchCode+MINMATCH);
+            }
+
+            if ((outputDirective) &&    /* Check output buffer overflow */
+                (unlikely(op + (1 + LASTLITERALS) + (matchCode+240)/255 > olimit)) ) {
+                if (outputDirective == fillOutput) {
+                    /* Match description too long : reduce it */
+                    U32 newMatchCode = 15 /* in token */ - 1 /* to avoid needing a zero byte */ + ((U32)(olimit - op) - 1 - LASTLITERALS) * 255;
+                    ip -= matchCode - newMatchCode;
+                    assert(newMatchCode < matchCode);
+                    matchCode = newMatchCode;
+                    if (unlikely(ip <= filledIp)) {
+                        /* We have already filled up to filledIp so if ip ends up less than filledIp
+                         * we have positions in the hash table beyond the current position. This is
+                         * a problem if we reuse the hash table. So we have to remove these positions
+                         * from the hash table.
+                         */
+                        const BYTE* ptr;
+                        DEBUGLOG(5, "Clearing %u positions", (U32)(filledIp - ip));
+                        for (ptr = ip; ptr <= filledIp; ++ptr) {
+                            U32 const h = LZ4_hashPosition(ptr, tableType);
+                            LZ4_clearHash(h, cctx->hashTable, tableType);
+                        }
+                    }
+                } else {
+                    assert(outputDirective == limitedOutput);
+                    return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+                }
+            }
+            if (matchCode >= ML_MASK) {
+                *token += ML_MASK;
+                matchCode -= ML_MASK;
+                LZ4_write32(op, 0xFFFFFFFF);
+                while (matchCode >= 4*255) {
+                    op+=4;
+                    LZ4_write32(op, 0xFFFFFFFF);
+                    matchCode -= 4*255;
+                }
+                op += matchCode / 255;
+                *op++ = (BYTE)(matchCode % 255);
+            } else
+                *token += (BYTE)(matchCode);
+        }
+        /* Ensure we have enough space for the last literals. */
+        assert(!(outputDirective == fillOutput && op + 1 + LASTLITERALS > olimit));
+
+        anchor = ip;
+
+        /* Test end of chunk */
+        if (ip >= mflimitPlusOne) break;
+
+        /* Fill table */
+        {   U32 const h = LZ4_hashPosition(ip-2, tableType);
+            if (tableType == byPtr) {
+                LZ4_putPositionOnHash(ip-2, h, cctx->hashTable, byPtr);
+            } else {
+                U32 const idx = (U32)((ip-2) - base);
+                LZ4_putIndexOnHash(idx, h, cctx->hashTable, tableType);
+        }   }
+
+        /* Test next position */
+        if (tableType == byPtr) {
+
+            match = LZ4_getPosition(ip, cctx->hashTable, tableType);
+            LZ4_putPosition(ip, cctx->hashTable, tableType);
+            if ( (match+LZ4_DISTANCE_MAX >= ip)
+              && (LZ4_read32(match) == LZ4_read32(ip)) )
+            { token=op++; *token=0; goto _next_match; }
+
+        } else {   /* byU32, byU16 */
+
+            U32 const h = LZ4_hashPosition(ip, tableType);
+            U32 const current = (U32)(ip-base);
+            U32 matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
+            assert(matchIndex < current);
+            if (dictDirective == usingDictCtx) {
+                if (matchIndex < startIndex) {
+                    /* there was no match, try the dictionary */
+                    assert(tableType == byU32);
+                    matchIndex = LZ4_getIndexOnHash(h, dictCtx->hashTable, byU32);
+                    match = dictBase + matchIndex;
+                    lowLimit = dictionary;   /* required for match length counter */
+                    matchIndex += dictDelta;
+                } else {
+                    match = base + matchIndex;
+                    lowLimit = (const BYTE*)source;  /* required for match length counter */
+                }
+            } else if (dictDirective==usingExtDict) {
+                if (matchIndex < startIndex) {
+                    assert(dictBase);
+                    match = dictBase + matchIndex;
+                    lowLimit = dictionary;   /* required for match length counter */
+                } else {
+                    match = base + matchIndex;
+                    lowLimit = (const BYTE*)source;   /* required for match length counter */
+                }
+            } else {   /* single memory segment */
+                match = base + matchIndex;
+            }
+            LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
+            assert(matchIndex < current);
+            if ( ((dictIssue==dictSmall) ? (matchIndex >= prefixIdxLimit) : 1)
+              && (((tableType==byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX)) ? 1 : (matchIndex+LZ4_DISTANCE_MAX >= current))
+              && (LZ4_read32(match) == LZ4_read32(ip)) ) {
+                token=op++;
+                *token=0;
+                if (maybe_extMem) offset = current - matchIndex;
+                DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i",
+                            (int)(anchor-(const BYTE*)source), 0, (int)(ip-(const BYTE*)source));
+                goto _next_match;
+            }
+        }
+
+        /* Prepare next loop */
+        forwardH = LZ4_hashPosition(++ip, tableType);
+
+    }
+
+_last_literals:
+    /* Encode Last Literals */
+    {   size_t lastRun = (size_t)(iend - anchor);
+        if ( (outputDirective) &&  /* Check output buffer overflow */
+            (op + lastRun + 1 + ((lastRun+255-RUN_MASK)/255) > olimit)) {
+            if (outputDirective == fillOutput) {
+                /* adapt lastRun to fill 'dst' */
+                assert(olimit >= op);
+                lastRun  = (size_t)(olimit-op) - 1/*token*/;
+                lastRun -= (lastRun + 256 - RUN_MASK) / 256;  /*additional length tokens*/
+            } else {
+                assert(outputDirective == limitedOutput);
+                return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+            }
+        }
+        DEBUGLOG(6, "Final literal run : %i literals", (int)lastRun);
+        if (lastRun >= RUN_MASK) {
+            size_t accumulator = lastRun - RUN_MASK;
+            *op++ = RUN_MASK << ML_BITS;
+            for(; accumulator >= 255 ; accumulator-=255) *op++ = 255;
+            *op++ = (BYTE) accumulator;
+        } else {
+            *op++ = (BYTE)(lastRun<<ML_BITS);
+        }
+        LZ4_memcpy(op, anchor, lastRun);
+        ip = anchor + lastRun;
+        op += lastRun;
+    }
+
+    if (outputDirective == fillOutput) {
+        *inputConsumed = (int) (((const char*)ip)-source);
+    }
+    result = (int)(((char*)op) - dest);
+    assert(result > 0);
+    DEBUGLOG(5, "LZ4_compress_generic: compressed %i bytes into %i bytes", inputSize, result);
+    return result;
+}
+
+/** LZ4_compress_generic() :
+ *  inlined, to ensure branches are decided at compilation time;
+ *  takes care of src == (NULL, 0)
+ *  and forward the rest to LZ4_compress_generic_validated */
+LZ4_FORCE_INLINE int LZ4_compress_generic(
+                 LZ4_stream_t_internal* const cctx,
+                 const char* const src,
+                 char* const dst,
+                 const int srcSize,
+                 int *inputConsumed, /* only written when outputDirective == fillOutput */
+                 const int dstCapacity,
+                 const limitedOutput_directive outputDirective,
+                 const tableType_t tableType,
+                 const dict_directive dictDirective,
+                 const dictIssue_directive dictIssue,
+                 const int acceleration)
+{
+    DEBUGLOG(5, "LZ4_compress_generic: srcSize=%i, dstCapacity=%i",
+                srcSize, dstCapacity);
+
+    if ((U32)srcSize > (U32)LZ4_MAX_INPUT_SIZE) { return 0; }  /* Unsupported srcSize, too large (or negative) */
+    if (srcSize == 0) {   /* src == NULL supported if srcSize == 0 */
+        if (outputDirective != notLimited && dstCapacity <= 0) return 0;  /* no output, can't write anything */
+        DEBUGLOG(5, "Generating an empty block");
+        assert(outputDirective == notLimited || dstCapacity >= 1);
+        assert(dst != NULL);
+        dst[0] = 0;
+        if (outputDirective == fillOutput) {
+            assert (inputConsumed != NULL);
+            *inputConsumed = 0;
+        }
+        return 1;
+    }
+    assert(src != NULL);
+
+    return LZ4_compress_generic_validated(cctx, src, dst, srcSize,
+                inputConsumed, /* only written into if outputDirective == fillOutput */
+                dstCapacity, outputDirective,
+                tableType, dictDirective, dictIssue, acceleration);
+}
+
+
+int LZ4_compress_fast_extState(void* state, const char* source, char* dest, int inputSize, int maxOutputSize, int acceleration)
+{
+    LZ4_stream_t_internal* const ctx = & LZ4_initStream(state, sizeof(LZ4_stream_t)) -> internal_donotuse;
+    assert(ctx != NULL);
+    if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
+    if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
+    if (maxOutputSize >= LZ4_compressBound(inputSize)) {
+        if (inputSize < LZ4_64Klimit) {
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, byU16, noDict, noDictIssue, acceleration);
+        } else {
+            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)source > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+        }
+    } else {
+        if (inputSize < LZ4_64Klimit) {
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, byU16, noDict, noDictIssue, acceleration);
+        } else {
+            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)source > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+        }
+    }
+}
+
+/**
+ * LZ4_compress_fast_extState_fastReset() :
+ * A variant of LZ4_compress_fast_extState().
+ *
+ * Using this variant avoids an expensive initialization step. It is only safe
+ * to call if the state buffer is known to be correctly initialized already
+ * (see comment in lz4.h on LZ4_resetStream_fast() for a definition of
+ * "correctly initialized").
+ */
+int LZ4_compress_fast_extState_fastReset(void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration)
+{
+    LZ4_stream_t_internal* const ctx = &((LZ4_stream_t*)state)->internal_donotuse;
+    if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
+    if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
+    assert(ctx != NULL);
+
+    if (dstCapacity >= LZ4_compressBound(srcSize)) {
+        if (srcSize < LZ4_64Klimit) {
+            const tableType_t tableType = byU16;
+            LZ4_prepareTable(ctx, srcSize, tableType);
+            if (ctx->currentOffset) {
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, dictSmall, acceleration);
+            } else {
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+            }
+        } else {
+            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            LZ4_prepareTable(ctx, srcSize, tableType);
+            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+        }
+    } else {
+        if (srcSize < LZ4_64Klimit) {
+            const tableType_t tableType = byU16;
+            LZ4_prepareTable(ctx, srcSize, tableType);
+            if (ctx->currentOffset) {
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, dictSmall, acceleration);
+            } else {
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+            }
+        } else {
+            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            LZ4_prepareTable(ctx, srcSize, tableType);
+            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+        }
+    }
+}
+
+
+int LZ4_compress_fast(const char* src, char* dest, int srcSize, int dstCapacity, int acceleration)
+{
+    int result;
+#if (LZ4_HEAPMODE)
+    LZ4_stream_t* const ctxPtr = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));   /* malloc-calloc always properly aligned */
+    if (ctxPtr == NULL) return 0;
+#else
+    LZ4_stream_t ctx;
+    LZ4_stream_t* const ctxPtr = &ctx;
+#endif
+    result = LZ4_compress_fast_extState(ctxPtr, src, dest, srcSize, dstCapacity, acceleration);
+
+#if (LZ4_HEAPMODE)
+    FREEMEM(ctxPtr);
+#endif
+    return result;
+}
+
+
+int LZ4_compress_default(const char* src, char* dst, int srcSize, int dstCapacity)
+{
+    return LZ4_compress_fast(src, dst, srcSize, dstCapacity, 1);
+}
+
+
+/* Note!: This function leaves the stream in an unclean/broken state!
+ * It is not safe to subsequently use the same state with a _fastReset() or
+ * _continue() call without resetting it. */
+static int LZ4_compress_destSize_extState_internal(LZ4_stream_t* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
+{
+    void* const s = LZ4_initStream(state, sizeof (*state));
+    assert(s != NULL); (void)s;
+
+    if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) {  /* compression success is guaranteed */
+        return LZ4_compress_fast_extState(state, src, dst, *srcSizePtr, targetDstSize, acceleration);
+    } else {
+        if (*srcSizePtr < LZ4_64Klimit) {
+            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, byU16, noDict, noDictIssue, acceleration);
+        } else {
+            tableType_t const addrMode = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, addrMode, noDict, noDictIssue, acceleration);
+    }   }
+}
+
+int LZ4_compress_destSize_extState(void* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
+{
+    int const r = LZ4_compress_destSize_extState_internal((LZ4_stream_t*)state, src, dst, srcSizePtr, targetDstSize, acceleration);
+    /* clean the state on exit */
+    LZ4_initStream(state, sizeof (LZ4_stream_t));
+    return r;
+}
+
+
+int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targetDstSize)
+{
+#if (LZ4_HEAPMODE)
+    LZ4_stream_t* const ctx = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));   /* malloc-calloc always properly aligned */
+    if (ctx == NULL) return 0;
+#else
+    LZ4_stream_t ctxBody;
+    LZ4_stream_t* const ctx = &ctxBody;
+#endif
+
+    int result = LZ4_compress_destSize_extState_internal(ctx, src, dst, srcSizePtr, targetDstSize, 1);
+
+#if (LZ4_HEAPMODE)
+    FREEMEM(ctx);
+#endif
+    return result;
+}
+
+
+
+/*-******************************
+*  Streaming functions
+********************************/
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4_stream_t* LZ4_createStream(void)
+{
+    LZ4_stream_t* const lz4s = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));
+    LZ4_STATIC_ASSERT(sizeof(LZ4_stream_t) >= sizeof(LZ4_stream_t_internal));
+    DEBUGLOG(4, "LZ4_createStream %p", lz4s);
+    if (lz4s == NULL) return NULL;
+    LZ4_initStream(lz4s, sizeof(*lz4s));
+    return lz4s;
+}
+#endif
+
+static size_t LZ4_stream_t_alignment(void)
+{
+#if LZ4_ALIGN_TEST
+    typedef struct { char c; LZ4_stream_t t; } t_a;
+    return sizeof(t_a) - sizeof(LZ4_stream_t);
+#else
+    return 1;  /* effectively disabled */
+#endif
+}
+
+LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
+{
+    DEBUGLOG(5, "LZ4_initStream");
+    if (buffer == NULL) { return NULL; }
+    if (size < sizeof(LZ4_stream_t)) { return NULL; }
+    if (!LZ4_isAligned(buffer, LZ4_stream_t_alignment())) return NULL;
+    MEM_INIT(buffer, 0, sizeof(LZ4_stream_t_internal));
+    return (LZ4_stream_t*)buffer;
+}
+
+/* resetStream is now deprecated,
+ * prefer initStream() which is more general */
+void LZ4_resetStream (LZ4_stream_t* LZ4_stream)
+{
+    DEBUGLOG(5, "LZ4_resetStream (ctx:%p)", LZ4_stream);
+    MEM_INIT(LZ4_stream, 0, sizeof(LZ4_stream_t_internal));
+}
+
+void LZ4_resetStream_fast(LZ4_stream_t* ctx) {
+    LZ4_prepareTable(&(ctx->internal_donotuse), 0, byU32);
+}
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
+{
+    if (!LZ4_stream) return 0;   /* support free on NULL */
+    DEBUGLOG(5, "LZ4_freeStream %p", LZ4_stream);
+    FREEMEM(LZ4_stream);
+    return (0);
+}
+#endif
+
+
+typedef enum { _ld_fast, _ld_slow } LoadDict_mode_e;
+#define HASH_UNIT sizeof(reg_t)
+int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict,
+                    const char* dictionary, int dictSize,
+                    LoadDict_mode_e _ld)
+{
+    LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
+    const tableType_t tableType = byU32;
+    const BYTE* p = (const BYTE*)dictionary;
+    const BYTE* const dictEnd = p + dictSize;
+    U32 idx32;
+
+    DEBUGLOG(4, "LZ4_loadDict (%i bytes from %p into %p)", dictSize, dictionary, LZ4_dict);
+
+    /* It's necessary to reset the context,
+     * and not just continue it with prepareTable()
+     * to avoid any risk of generating overflowing matchIndex
+     * when compressing using this dictionary */
+    LZ4_resetStream(LZ4_dict);
+
+    /* We always increment the offset by 64 KB, since, if the dict is longer,
+     * we truncate it to the last 64k, and if it's shorter, we still want to
+     * advance by a whole window length so we can provide the guarantee that
+     * there are only valid offsets in the window, which allows an optimization
+     * in LZ4_compress_fast_continue() where it uses noDictIssue even when the
+     * dictionary isn't a full 64k. */
+    dict->currentOffset += 64 KB;
+
+    if (dictSize < (int)HASH_UNIT) {
+        return 0;
+    }
+
+    if ((dictEnd - p) > 64 KB) p = dictEnd - 64 KB;
+    dict->dictionary = p;
+    dict->dictSize = (U32)(dictEnd - p);
+    dict->tableType = (U32)tableType;
+    idx32 = dict->currentOffset - dict->dictSize;
+
+    while (p <= dictEnd-HASH_UNIT) {
+        U32 const h = LZ4_hashPosition(p, tableType);
+        /* Note: overwriting => favors positions end of dictionary */
+        LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
+        p+=3; idx32+=3;
+    }
+
+    if (_ld == _ld_slow) {
+        /* Fill hash table with additional references, to improve compression capability */
+        p = dict->dictionary;
+        idx32 = dict->currentOffset - dict->dictSize;
+        while (p <= dictEnd-HASH_UNIT) {
+            U32 const h = LZ4_hashPosition(p, tableType);
+            U32 const limit = dict->currentOffset - 64 KB;
+            if (LZ4_getIndexOnHash(h, dict->hashTable, tableType) <= limit) {
+                /* Note: not overwriting => favors positions beginning of dictionary */
+                LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
+            }
+            p++; idx32++;
+        }
+    }
+
+    return (int)dict->dictSize;
+}
+
+int LZ4_loadDict(LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
+{
+    return LZ4_loadDict_internal(LZ4_dict, dictionary, dictSize, _ld_fast);
+}
+
+int LZ4_loadDictSlow(LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
+{
+    return LZ4_loadDict_internal(LZ4_dict, dictionary, dictSize, _ld_slow);
+}
+
+void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dictionaryStream)
+{
+    const LZ4_stream_t_internal* dictCtx = (dictionaryStream == NULL) ? NULL :
+        &(dictionaryStream->internal_donotuse);
+
+    DEBUGLOG(4, "LZ4_attach_dictionary (%p, %p, size %u)",
+             workingStream, dictionaryStream,
+             dictCtx != NULL ? dictCtx->dictSize : 0);
+
+    if (dictCtx != NULL) {
+        /* If the current offset is zero, we will never look in the
+         * external dictionary context, since there is no value a table
+         * entry can take that indicate a miss. In that case, we need
+         * to bump the offset to something non-zero.
+         */
+        if (workingStream->internal_donotuse.currentOffset == 0) {
+            workingStream->internal_donotuse.currentOffset = 64 KB;
+        }
+
+        /* Don't actually attach an empty dictionary.
+         */
+        if (dictCtx->dictSize == 0) {
+            dictCtx = NULL;
+        }
+    }
+    workingStream->internal_donotuse.dictCtx = dictCtx;
+}
+
+
+static void LZ4_renormDictT(LZ4_stream_t_internal* LZ4_dict, int nextSize)
+{
+    assert(nextSize >= 0);
+    if (LZ4_dict->currentOffset + (unsigned)nextSize > 0x80000000) {   /* potential ptrdiff_t overflow (32-bits mode) */
+        /* rescale hash table */
+        U32 const delta = LZ4_dict->currentOffset - 64 KB;
+        const BYTE* dictEnd = LZ4_dict->dictionary + LZ4_dict->dictSize;
+        int i;
+        DEBUGLOG(4, "LZ4_renormDictT");
+        for (i=0; i<LZ4_HASH_SIZE_U32; i++) {
+            if (LZ4_dict->hashTable[i] < delta) LZ4_dict->hashTable[i]=0;
+            else LZ4_dict->hashTable[i] -= delta;
+        }
+        LZ4_dict->currentOffset = 64 KB;
+        if (LZ4_dict->dictSize > 64 KB) LZ4_dict->dictSize = 64 KB;
+        LZ4_dict->dictionary = dictEnd - LZ4_dict->dictSize;
+    }
+}
+
+
+int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
+                                const char* source, char* dest,
+                                int inputSize, int maxOutputSize,
+                                int acceleration)
+{
+    const tableType_t tableType = byU32;
+    LZ4_stream_t_internal* const streamPtr = &LZ4_stream->internal_donotuse;
+    const char* dictEnd = streamPtr->dictSize ? (const char*)streamPtr->dictionary + streamPtr->dictSize : NULL;
+
+    DEBUGLOG(5, "LZ4_compress_fast_continue (inputSize=%i, dictSize=%u)", inputSize, streamPtr->dictSize);
+
+    LZ4_renormDictT(streamPtr, inputSize);   /* fix index overflow */
+    if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
+    if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
+
+    /* invalidate tiny dictionaries */
+    if ( (streamPtr->dictSize < 4)     /* tiny dictionary : not enough for a hash */
+      && (dictEnd != source)           /* prefix mode */
+      && (inputSize > 0)               /* tolerance : don't lose history, in case next invocation would use prefix mode */
+      && (streamPtr->dictCtx == NULL)  /* usingDictCtx */
+      ) {
+        DEBUGLOG(5, "LZ4_compress_fast_continue: dictSize(%u) at addr:%p is too small", streamPtr->dictSize, streamPtr->dictionary);
+        /* remove dictionary existence from history, to employ faster prefix mode */
+        streamPtr->dictSize = 0;
+        streamPtr->dictionary = (const BYTE*)source;
+        dictEnd = source;
+    }
+
+    /* Check overlapping input/dictionary space */
+    {   const char* const sourceEnd = source + inputSize;
+        if ((sourceEnd > (const char*)streamPtr->dictionary) && (sourceEnd < dictEnd)) {
+            streamPtr->dictSize = (U32)(dictEnd - sourceEnd);
+            if (streamPtr->dictSize > 64 KB) streamPtr->dictSize = 64 KB;
+            if (streamPtr->dictSize < 4) streamPtr->dictSize = 0;
+            streamPtr->dictionary = (const BYTE*)dictEnd - streamPtr->dictSize;
+        }
+    }
+
+    /* prefix mode : source data follows dictionary */
+    if (dictEnd == source) {
+        if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset))
+            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, withPrefix64k, dictSmall, acceleration);
+        else
+            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, withPrefix64k, noDictIssue, acceleration);
+    }
+
+    /* external dictionary mode */
+    {   int result;
+        if (streamPtr->dictCtx) {
+            /* We depend here on the fact that dictCtx'es (produced by
+             * LZ4_loadDict) guarantee that their tables contain no references
+             * to offsets between dictCtx->currentOffset - 64 KB and
+             * dictCtx->currentOffset - dictCtx->dictSize. This makes it safe
+             * to use noDictIssue even when the dict isn't a full 64 KB.
+             */
+            if (inputSize > 4 KB) {
+                /* For compressing large blobs, it is faster to pay the setup
+                 * cost to copy the dictionary's tables into the active context,
+                 * so that the compression loop is only looking into one table.
+                 */
+                LZ4_memcpy(streamPtr, streamPtr->dictCtx, sizeof(*streamPtr));
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, noDictIssue, acceleration);
+            } else {
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingDictCtx, noDictIssue, acceleration);
+            }
+        } else {  /* small data <= 4 KB */
+            if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset)) {
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, dictSmall, acceleration);
+            } else {
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, noDictIssue, acceleration);
+            }
+        }
+        streamPtr->dictionary = (const BYTE*)source;
+        streamPtr->dictSize = (U32)inputSize;
+        return result;
+    }
+}
+
+
+/* Hidden debug function, to force-test external dictionary mode */
+int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize)
+{
+    LZ4_stream_t_internal* const streamPtr = &LZ4_dict->internal_donotuse;
+    int result;
+
+    LZ4_renormDictT(streamPtr, srcSize);
+
+    if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset)) {
+        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32, usingExtDict, dictSmall, 1);
+    } else {
+        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32, usingExtDict, noDictIssue, 1);
+    }
+
+    streamPtr->dictionary = (const BYTE*)source;
+    streamPtr->dictSize = (U32)srcSize;
+
+    return result;
+}
+
+
+/*! LZ4_saveDict() :
+ *  If previously compressed data block is not guaranteed to remain available at its memory location,
+ *  save it into a safer place (char* safeBuffer).
+ *  Note : no need to call LZ4_loadDict() afterwards, dictionary is immediately usable,
+ *         one can therefore call LZ4_compress_fast_continue() right after.
+ * @return : saved dictionary size in bytes (necessarily <= dictSize), or 0 if error.
+ */
+int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
+{
+    LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
+
+    DEBUGLOG(5, "LZ4_saveDict : dictSize=%i, safeBuffer=%p", dictSize, safeBuffer);
+
+    if ((U32)dictSize > 64 KB) { dictSize = 64 KB; } /* useless to define a dictionary > 64 KB */
+    if ((U32)dictSize > dict->dictSize) { dictSize = (int)dict->dictSize; }
+
+    if (safeBuffer == NULL) assert(dictSize == 0);
+    if (dictSize > 0) {
+        const BYTE* const previousDictEnd = dict->dictionary + dict->dictSize;
+        assert(dict->dictionary);
+        LZ4_memmove(safeBuffer, previousDictEnd - dictSize, (size_t)dictSize);
+    }
+
+    dict->dictionary = (const BYTE*)safeBuffer;
+    dict->dictSize = (U32)dictSize;
+
+    return dictSize;
+}
+
+
+
+/*-*******************************
+ *  Decompression functions
+ ********************************/
+
+typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
+
+#undef MIN
+#define MIN(a,b)    ( (a) < (b) ? (a) : (b) )
+
+
+/* variant for decompress_unsafe()
+ * does not know end of input
+ * presumes input is well formed
+ * note : will consume at least one byte */
+static size_t read_long_length_no_check(const BYTE** pp)
+{
+    size_t b, l = 0;
+    do { b = **pp; (*pp)++; l += b; } while (b==255);
+    DEBUGLOG(6, "read_long_length_no_check: +length=%zu using %zu input bytes", l, l/255 + 1)
+    return l;
+}
+
+/* core decoder variant for LZ4_decompress_fast*()
+ * for legacy support only : these entry points are deprecated.
+ * - Presumes input is correctly formed (no defense vs malformed inputs)
+ * - Does not know input size (presume input buffer is "large enough")
+ * - Decompress a full block (only)
+ * @return : nb of bytes read from input.
+ * Note : this variant is not optimized for speed, just for maintenance.
+ *        the goal is to remove support of decompress_fast*() variants by v2.0
+**/
+LZ4_FORCE_INLINE int
+LZ4_decompress_unsafe_generic(
+                 const BYTE* const istart,
+                 BYTE* const ostart,
+                 int decompressedSize,
+
+                 size_t prefixSize,
+                 const BYTE* const dictStart,  /* only if dict==usingExtDict */
+                 const size_t dictSize         /* note: =0 if dictStart==NULL */
+                 )
+{
+    const BYTE* ip = istart;
+    BYTE* op = (BYTE*)ostart;
+    BYTE* const oend = ostart + decompressedSize;
+    const BYTE* const prefixStart = ostart - prefixSize;
+
+    DEBUGLOG(5, "LZ4_decompress_unsafe_generic");
+    if (dictStart == NULL) assert(dictSize == 0);
+
+    while (1) {
+        /* start new sequence */
+        unsigned token = *ip++;
+
+        /* literals */
+        {   size_t ll = token >> ML_BITS;
+            if (ll==15) {
+                /* long literal length */
+                ll += read_long_length_no_check(&ip);
+            }
+            if ((size_t)(oend-op) < ll) return -1; /* output buffer overflow */
+            LZ4_memmove(op, ip, ll); /* support in-place decompression */
+            op += ll;
+            ip += ll;
+            if ((size_t)(oend-op) < MFLIMIT) {
+                if (op==oend) break;  /* end of block */
+                DEBUGLOG(5, "invalid: literals end at distance %zi from end of block", oend-op);
+                /* incorrect end of block :
+                 * last match must start at least MFLIMIT==12 bytes before end of output block */
+                return -1;
+        }   }
+
+        /* match */
+        {   size_t ml = token & 15;
+            size_t const offset = LZ4_readLE16(ip);
+            ip+=2;
+
+            if (ml==15) {
+                /* long literal length */
+                ml += read_long_length_no_check(&ip);
+            }
+            ml += MINMATCH;
+
+            if ((size_t)(oend-op) < ml) return -1; /* output buffer overflow */
+
+            {   const BYTE* match = op - offset;
+
+                /* out of range */
+                if (offset > (size_t)(op - prefixStart) + dictSize) {
+                    DEBUGLOG(6, "offset out of range");
+                    return -1;
+                }
+
+                /* check special case : extDict */
+                if (offset > (size_t)(op - prefixStart)) {
+                    /* extDict scenario */
+                    const BYTE* const dictEnd = dictStart + dictSize;
+                    const BYTE* extMatch = dictEnd - (offset - (size_t)(op-prefixStart));
+                    size_t const extml = (size_t)(dictEnd - extMatch);
+                    if (extml > ml) {
+                        /* match entirely within extDict */
+                        LZ4_memmove(op, extMatch, ml);
+                        op += ml;
+                        ml = 0;
+                    } else {
+                        /* match split between extDict & prefix */
+                        LZ4_memmove(op, extMatch, extml);
+                        op += extml;
+                        ml -= extml;
+                    }
+                    match = prefixStart;
+                }
+
+                /* match copy - slow variant, supporting overlap copy */
+                {   size_t u;
+                    for (u=0; u<ml; u++) {
+                        op[u] = match[u];
+            }   }   }
+            op += ml;
+            if ((size_t)(oend-op) < LASTLITERALS) {
+                DEBUGLOG(5, "invalid: match ends at distance %zi from end of block", oend-op);
+                /* incorrect end of block :
+                 * last match must stop at least LASTLITERALS==5 bytes before end of output block */
+                return -1;
+            }
+        } /* match */
+    } /* main loop */
+    return (int)(ip - istart);
+}
+
+
+/* Read the variable-length literal or match length.
+ *
+ * @ip : input pointer
+ * @ilimit : position after which if length is not decoded, the input is necessarily corrupted.
+ * @initial_check - check ip >= ipmax before start of loop.  Returns initial_error if so.
+ * @error (output) - error code.  Must be set to 0 before call.
+**/
+typedef size_t Rvl_t;
+static const Rvl_t rvl_error = (Rvl_t)(-1);
+LZ4_FORCE_INLINE Rvl_t
+read_variable_length(const BYTE** ip, const BYTE* ilimit,
+                     int initial_check)
+{
+    Rvl_t s, length = 0;
+    assert(ip != NULL);
+    assert(*ip !=  NULL);
+    assert(ilimit != NULL);
+    if (initial_check && unlikely((*ip) >= ilimit)) {    /* read limit reached */
+        return rvl_error;
+    }
+    s = **ip;
+    (*ip)++;
+    length += s;
+    if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+        return rvl_error;
+    }
+    /* accumulator overflow detection (32-bit mode only) */
+    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+        return rvl_error;
+    }
+    if (likely(s != 255)) return length;
+    do {
+        s = **ip;
+        (*ip)++;
+        length += s;
+        if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+            return rvl_error;
+        }
+        /* accumulator overflow detection (32-bit mode only) */
+        if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+            return rvl_error;
+        }
+    } while (s == 255);
+
+    return length;
+}
+
+/*! LZ4_decompress_generic() :
+ *  This generic decompression function covers all use cases.
+ *  It shall be instantiated several times, using different sets of directives.
+ *  Note that it is important for performance that this function really get inlined,
+ *  in order to remove useless branches during compilation optimization.
+ */
+LZ4_FORCE_INLINE int
+LZ4_decompress_generic(
+                 const char* const src,
+                 char* const dst,
+                 int srcSize,
+                 int outputSize,         /* If endOnInput==endOnInputSize, this value is `dstCapacity` */
+
+                 earlyEnd_directive partialDecoding,  /* full, partial */
+                 dict_directive dict,                 /* noDict, withPrefix64k, usingExtDict */
+                 const BYTE* const lowPrefix,  /* always <= dst, == dst when no prefix */
+                 const BYTE* const dictStart,  /* only if dict==usingExtDict */
+                 const size_t dictSize         /* note : = 0 if noDict */
+                 )
+{
+    if ((src == NULL) || (outputSize < 0)) { return -1; }
+
+    {   const BYTE* ip = (const BYTE*) src;
+        const BYTE* const iend = ip + srcSize;
+
+        BYTE* op = (BYTE*) dst;
+        BYTE* const oend = op + outputSize;
+        BYTE* cpy;
+
+        const BYTE* const dictEnd = (dictStart == NULL) ? NULL : dictStart + dictSize;
+
+        const int checkOffset = (dictSize < (int)(64 KB));
+
+
+        /* Set up the "end" pointers for the shortcut. */
+        const BYTE* const shortiend = iend - 14 /*maxLL*/ - 2 /*offset*/;
+        const BYTE* const shortoend = oend - 14 /*maxLL*/ - 18 /*maxML*/;
+
+        const BYTE* match;
+        size_t offset;
+        unsigned token;
+        size_t length;
+
+
+        DEBUGLOG(5, "LZ4_decompress_generic (srcSize:%i, dstSize:%i)", srcSize, outputSize);
+
+        /* Special cases */
+        assert(lowPrefix <= op);
+        if (unlikely(outputSize==0)) {
+            /* Empty output buffer */
+            if (partialDecoding) return 0;
+            return ((srcSize==1) && (*ip==0)) ? 0 : -1;
+        }
+        if (unlikely(srcSize==0)) { return -1; }
+
+    /* LZ4_FAST_DEC_LOOP:
+     * designed for modern OoO performance cpus,
+     * where copying reliably 32-bytes is preferable to an unpredictable branch.
+     * note : fast loop may show a regression for some client arm chips. */
+#if LZ4_FAST_DEC_LOOP
+        if ((oend - op) < FASTLOOP_SAFE_DISTANCE) {
+            DEBUGLOG(6, "move to safe decode loop");
+            goto safe_decode;
+        }
+
+        /* Fast loop : decode sequences as long as output < oend-FASTLOOP_SAFE_DISTANCE */
+        DEBUGLOG(6, "using fast decode loop");
+        while (1) {
+            /* Main fastloop assertion: We can always wildcopy FASTLOOP_SAFE_DISTANCE */
+            assert(oend - op >= FASTLOOP_SAFE_DISTANCE);
+            assert(ip < iend);
+            token = *ip++;
+            length = token >> ML_BITS;  /* literal length */
+            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+
+            /* decode literal length */
+            if (length == RUN_MASK) {
+                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                if (addl == rvl_error) {
+                    DEBUGLOG(6, "error reading long literal length");
+                    goto _output_error;
+                }
+                length += addl;
+                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+
+                /* copy literals */
+                LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
+                if ((op+length>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
+                LZ4_wildCopy32(op, ip, op+length);
+                ip += length; op += length;
+            } else if (ip <= iend-(16 + 1/*max lit + offset + nextToken*/)) {
+                /* We don't need to check oend, since we check it once for each loop below */
+                DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)length);
+                /* Literals can only be <= 14, but hope compilers optimize better when copy by a register size */
+                LZ4_memcpy(op, ip, 16);
+                ip += length; op += length;
+            } else {
+                goto safe_literal_copy;
+            }
+
+            /* get offset */
+            offset = LZ4_readLE16(ip); ip+=2;
+            DEBUGLOG(6, "blockPos%6u: offset = %u", (unsigned)(op-(BYTE*)dst), (unsigned)offset);
+            match = op - offset;
+            assert(match <= op);  /* overflow check */
+
+            /* get matchlength */
+            length = token & ML_MASK;
+            DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
+
+            if (length == ML_MASK) {
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                if (addl == rvl_error) {
+                    DEBUGLOG(5, "error reading long match length");
+                    goto _output_error;
+                }
+                length += addl;
+                length += MINMATCH;
+                DEBUGLOG(7, "  long match length == %u", (unsigned)length);
+                if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
+                if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
+                    goto safe_match_copy;
+                }
+            } else {
+                length += MINMATCH;
+                if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
+                    DEBUGLOG(7, "moving to safe_match_copy (ml==%u)", (unsigned)length);
+                    goto safe_match_copy;
+                }
+
+                /* Fastpath check: skip LZ4_wildCopy32 when true */
+                if ((dict == withPrefix64k) || (match >= lowPrefix)) {
+                    if (offset >= 8) {
+                        assert(match >= lowPrefix);
+                        assert(match <= op);
+                        assert(op + 18 <= oend);
+
+                        LZ4_memcpy(op, match, 8);
+                        LZ4_memcpy(op+8, match+8, 8);
+                        LZ4_memcpy(op+16, match+16, 2);
+                        op += length;
+                        continue;
+            }   }   }
+
+            if ( checkOffset && (unlikely(match + dictSize < lowPrefix)) ) {
+                DEBUGLOG(5, "Error : pos=%zi, offset=%zi => outside buffers", op-lowPrefix, op-match);
+                goto _output_error;
+            }
+            /* match starting within external dictionary */
+            if ((dict==usingExtDict) && (match < lowPrefix)) {
+                assert(dictEnd != NULL);
+                if (unlikely(op+length > oend-LASTLITERALS)) {
+                    if (partialDecoding) {
+                        DEBUGLOG(7, "partialDecoding: dictionary match, close to dstEnd");
+                        length = MIN(length, (size_t)(oend-op));
+                    } else {
+                        DEBUGLOG(6, "end-of-block condition violated")
+                        goto _output_error;
+                }   }
+
+                if (length <= (size_t)(lowPrefix-match)) {
+                    /* match fits entirely within external dictionary : just copy */
+                    LZ4_memmove(op, dictEnd - (lowPrefix-match), length);
+                    op += length;
+                } else {
+                    /* match stretches into both external dictionary and current block */
+                    size_t const copySize = (size_t)(lowPrefix - match);
+                    size_t const restSize = length - copySize;
+                    LZ4_memcpy(op, dictEnd - copySize, copySize);
+                    op += copySize;
+                    if (restSize > (size_t)(op - lowPrefix)) {  /* overlap copy */
+                        BYTE* const endOfMatch = op + restSize;
+                        const BYTE* copyFrom = lowPrefix;
+                        while (op < endOfMatch) { *op++ = *copyFrom++; }
+                    } else {
+                        LZ4_memcpy(op, lowPrefix, restSize);
+                        op += restSize;
+                }   }
+                continue;
+            }
+
+            /* copy match within block */
+            cpy = op + length;
+
+            assert((op <= oend) && (oend-op >= 32));
+            if (unlikely(offset<16)) {
+                LZ4_memcpy_using_offset(op, match, cpy, offset);
+            } else {
+                LZ4_wildCopy32(op, match, cpy);
+            }
+
+            op = cpy;   /* wildcopy correction */
+        }
+    safe_decode:
+#endif
+
+        /* Main Loop : decode remaining sequences where output < FASTLOOP_SAFE_DISTANCE */
+        DEBUGLOG(6, "using safe decode loop");
+        while (1) {
+            assert(ip < iend);
+            token = *ip++;
+            length = token >> ML_BITS;  /* literal length */
+            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+
+            /* A two-stage shortcut for the most common case:
+             * 1) If the literal length is 0..14, and there is enough space,
+             * enter the shortcut and copy 16 bytes on behalf of the literals
+             * (in the fast mode, only 8 bytes can be safely copied this way).
+             * 2) Further if the match length is 4..18, copy 18 bytes in a similar
+             * manner; but we ensure that there's enough space in the output for
+             * those 18 bytes earlier, upon entering the shortcut (in other words,
+             * there is a combined check for both stages).
+             */
+            if ( (length != RUN_MASK)
+                /* strictly "less than" on input, to re-enter the loop with at least one byte */
+              && likely((ip < shortiend) & (op <= shortoend)) ) {
+                /* Copy the literals */
+                LZ4_memcpy(op, ip, 16);
+                op += length; ip += length;
+
+                /* The second stage: prepare for match copying, decode full info.
+                 * If it doesn't work out, the info won't be wasted. */
+                length = token & ML_MASK; /* match length */
+                DEBUGLOG(7, "blockPos%6u: matchLength token = %u (len=%u)", (unsigned)(op-(BYTE*)dst), (unsigned)length, (unsigned)length + 4);
+                offset = LZ4_readLE16(ip); ip += 2;
+                match = op - offset;
+                assert(match <= op); /* check overflow */
+
+                /* Do not deal with overlapping matches. */
+                if ( (length != ML_MASK)
+                  && (offset >= 8)
+                  && (dict==withPrefix64k || match >= lowPrefix) ) {
+                    /* Copy the match. */
+                    LZ4_memcpy(op + 0, match + 0, 8);
+                    LZ4_memcpy(op + 8, match + 8, 8);
+                    LZ4_memcpy(op +16, match +16, 2);
+                    op += length + MINMATCH;
+                    /* Both stages worked, load the next token. */
+                    continue;
+                }
+
+                /* The second stage didn't work out, but the info is ready.
+                 * Propel it right to the point of match copying. */
+                goto _copy_match;
+            }
+
+            /* decode literal length */
+            if (length == RUN_MASK) {
+                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                if (addl == rvl_error) { goto _output_error; }
+                length += addl;
+                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+            }
+
+#if LZ4_FAST_DEC_LOOP
+        safe_literal_copy:
+#endif
+            /* copy literals */
+            cpy = op+length;
+
+            LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
+            if ((cpy>oend-MFLIMIT) || (ip+length>iend-(2+1+LASTLITERALS))) {
+                /* We've either hit the input parsing restriction or the output parsing restriction.
+                 * In the normal scenario, decoding a full block, it must be the last sequence,
+                 * otherwise it's an error (invalid input or dimensions).
+                 * In partialDecoding scenario, it's necessary to ensure there is no buffer overflow.
+                 */
+                if (partialDecoding) {
+                    /* Since we are partial decoding we may be in this block because of the output parsing
+                     * restriction, which is not valid since the output buffer is allowed to be undersized.
+                     */
+                    DEBUGLOG(7, "partialDecoding: copying literals, close to input or output end")
+                    DEBUGLOG(7, "partialDecoding: literal length = %u", (unsigned)length);
+                    DEBUGLOG(7, "partialDecoding: remaining space in dstBuffer : %i", (int)(oend - op));
+                    DEBUGLOG(7, "partialDecoding: remaining space in srcBuffer : %i", (int)(iend - ip));
+                    /* Finishing in the middle of a literals segment,
+                     * due to lack of input.
+                     */
+                    if (ip+length > iend) {
+                        length = (size_t)(iend-ip);
+                        cpy = op + length;
+                    }
+                    /* Finishing in the middle of a literals segment,
+                     * due to lack of output space.
+                     */
+                    if (cpy > oend) {
+                        cpy = oend;
+                        assert(op<=oend);
+                        length = (size_t)(oend-op);
+                    }
+                } else {
+                     /* We must be on the last sequence (or invalid) because of the parsing limitations
+                      * so check that we exactly consume the input and don't overrun the output buffer.
+                      */
+                    if ((ip+length != iend) || (cpy > oend)) {
+                        DEBUGLOG(5, "should have been last run of literals")
+                        DEBUGLOG(5, "ip(%p) + length(%i) = %p != iend (%p)", ip, (int)length, ip+length, iend);
+                        DEBUGLOG(5, "or cpy(%p) > (oend-MFLIMIT)(%p)", cpy, oend-MFLIMIT);
+                        DEBUGLOG(5, "after writing %u bytes / %i bytes available", (unsigned)(op-(BYTE*)dst), outputSize);
+                        goto _output_error;
+                    }
+                }
+                LZ4_memmove(op, ip, length);  /* supports overlapping memory regions, for in-place decompression scenarios */
+                ip += length;
+                op += length;
+                /* Necessarily EOF when !partialDecoding.
+                 * When partialDecoding, it is EOF if we've either
+                 * filled the output buffer or
+                 * can't proceed with reading an offset for following match.
+                 */
+                if (!partialDecoding || (cpy == oend) || (ip >= (iend-2))) {
+                    break;
+                }
+            } else {
+                LZ4_wildCopy8(op, ip, cpy);   /* can overwrite up to 8 bytes beyond cpy */
+                ip += length; op = cpy;
+            }
+
+            /* get offset */
+            offset = LZ4_readLE16(ip); ip+=2;
+            match = op - offset;
+
+            /* get matchlength */
+            length = token & ML_MASK;
+            DEBUGLOG(7, "blockPos%6u: matchLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+
+    _copy_match:
+            if (length == ML_MASK) {
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                if (addl == rvl_error) { goto _output_error; }
+                length += addl;
+                if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */
+            }
+            length += MINMATCH;
+
+#if LZ4_FAST_DEC_LOOP
+        safe_match_copy:
+#endif
+            if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) goto _output_error;   /* Error : offset outside buffers */
+            /* match starting within external dictionary */
+            if ((dict==usingExtDict) && (match < lowPrefix)) {
+                assert(dictEnd != NULL);
+                if (unlikely(op+length > oend-LASTLITERALS)) {
+                    if (partialDecoding) length = MIN(length, (size_t)(oend-op));
+                    else goto _output_error;   /* doesn't respect parsing restriction */
+                }
+
+                if (length <= (size_t)(lowPrefix-match)) {
+                    /* match fits entirely within external dictionary : just copy */
+                    LZ4_memmove(op, dictEnd - (lowPrefix-match), length);
+                    op += length;
+                } else {
+                    /* match stretches into both external dictionary and current block */
+                    size_t const copySize = (size_t)(lowPrefix - match);
+                    size_t const restSize = length - copySize;
+                    LZ4_memcpy(op, dictEnd - copySize, copySize);
+                    op += copySize;
+                    if (restSize > (size_t)(op - lowPrefix)) {  /* overlap copy */
+                        BYTE* const endOfMatch = op + restSize;
+                        const BYTE* copyFrom = lowPrefix;
+                        while (op < endOfMatch) *op++ = *copyFrom++;
+                    } else {
+                        LZ4_memcpy(op, lowPrefix, restSize);
+                        op += restSize;
+                }   }
+                continue;
+            }
+            assert(match >= lowPrefix);
+
+            /* copy match within block */
+            cpy = op + length;
+
+            /* partialDecoding : may end anywhere within the block */
+            assert(op<=oend);
+            if (partialDecoding && (cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
+                size_t const mlen = MIN(length, (size_t)(oend-op));
+                const BYTE* const matchEnd = match + mlen;
+                BYTE* const copyEnd = op + mlen;
+                if (matchEnd > op) {   /* overlap copy */
+                    while (op < copyEnd) { *op++ = *match++; }
+                } else {
+                    LZ4_memcpy(op, match, mlen);
+                }
+                op = copyEnd;
+                if (op == oend) { break; }
+                continue;
+            }
+
+            if (unlikely(offset<8)) {
+                LZ4_write32(op, 0);   /* silence msan warning when offset==0 */
+                op[0] = match[0];
+                op[1] = match[1];
+                op[2] = match[2];
+                op[3] = match[3];
+                match += inc32table[offset];
+                LZ4_memcpy(op+4, match, 4);
+                match -= dec64table[offset];
+            } else {
+                LZ4_memcpy(op, match, 8);
+                match += 8;
+            }
+            op += 8;
+
+            if (unlikely(cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
+                BYTE* const oCopyLimit = oend - (WILDCOPYLENGTH-1);
+                if (cpy > oend-LASTLITERALS) { goto _output_error; } /* Error : last LASTLITERALS bytes must be literals (uncompressed) */
+                if (op < oCopyLimit) {
+                    LZ4_wildCopy8(op, match, oCopyLimit);
+                    match += oCopyLimit - op;
+                    op = oCopyLimit;
+                }
+                while (op < cpy) { *op++ = *match++; }
+            } else {
+                LZ4_memcpy(op, match, 8);
+                if (length > 16) { LZ4_wildCopy8(op+8, match+8, cpy); }
+            }
+            op = cpy;   /* wildcopy correction */
+        }
+
+        /* end of decoding */
+        DEBUGLOG(5, "decoded %i bytes", (int) (((char*)op)-dst));
+        return (int) (((char*)op)-dst);     /* Nb of output bytes decoded */
+
+        /* Overflow error detected */
+    _output_error:
+        return (int) (-(((const char*)ip)-src))-1;
+    }
+}
+
+
+/*===== Instantiate the API decoding functions. =====*/
+
+LZ4_FORCE_O2
+int LZ4_decompress_safe(const char* source, char* dest, int compressedSize, int maxDecompressedSize)
+{
+    return LZ4_decompress_generic(source, dest, compressedSize, maxDecompressedSize,
+                                  decode_full_block, noDict,
+                                  (BYTE*)dest, NULL, 0);
+}
+
+LZ4_FORCE_O2
+int LZ4_decompress_safe_partial(const char* src, char* dst, int compressedSize, int targetOutputSize, int dstCapacity)
+{
+    dstCapacity = MIN(targetOutputSize, dstCapacity);
+    return LZ4_decompress_generic(src, dst, compressedSize, dstCapacity,
+                                  partial_decode,
+                                  noDict, (BYTE*)dst, NULL, 0);
+}
+
+LZ4_FORCE_O2
+int LZ4_decompress_fast(const char* source, char* dest, int originalSize)
+{
+    DEBUGLOG(5, "LZ4_decompress_fast");
+    return LZ4_decompress_unsafe_generic(
+                (const BYTE*)source, (BYTE*)dest, originalSize,
+                0, NULL, 0);
+}
+
+/*===== Instantiate a few more decoding cases, used more than once. =====*/
+
+LZ4_FORCE_O2 /* Exported, an obsolete API function. */
+int LZ4_decompress_safe_withPrefix64k(const char* source, char* dest, int compressedSize, int maxOutputSize)
+{
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
+                                  decode_full_block, withPrefix64k,
+                                  (BYTE*)dest - 64 KB, NULL, 0);
+}
+
+LZ4_FORCE_O2
+static int LZ4_decompress_safe_partial_withPrefix64k(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity)
+{
+    dstCapacity = MIN(targetOutputSize, dstCapacity);
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
+                                  partial_decode, withPrefix64k,
+                                  (BYTE*)dest - 64 KB, NULL, 0);
+}
+
+/* Another obsolete API function, paired with the previous one. */
+int LZ4_decompress_fast_withPrefix64k(const char* source, char* dest, int originalSize)
+{
+    return LZ4_decompress_unsafe_generic(
+                (const BYTE*)source, (BYTE*)dest, originalSize,
+                64 KB, NULL, 0);
+}
+
+LZ4_FORCE_O2
+static int LZ4_decompress_safe_withSmallPrefix(const char* source, char* dest, int compressedSize, int maxOutputSize,
+                                               size_t prefixSize)
+{
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
+                                  decode_full_block, noDict,
+                                  (BYTE*)dest-prefixSize, NULL, 0);
+}
+
+LZ4_FORCE_O2
+static int LZ4_decompress_safe_partial_withSmallPrefix(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity,
+                                               size_t prefixSize)
+{
+    dstCapacity = MIN(targetOutputSize, dstCapacity);
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
+                                  partial_decode, noDict,
+                                  (BYTE*)dest-prefixSize, NULL, 0);
+}
+
+LZ4_FORCE_O2
+int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
+                                     int compressedSize, int maxOutputSize,
+                                     const void* dictStart, size_t dictSize)
+{
+    DEBUGLOG(5, "LZ4_decompress_safe_forceExtDict");
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
+                                  decode_full_block, usingExtDict,
+                                  (BYTE*)dest, (const BYTE*)dictStart, dictSize);
+}
+
+LZ4_FORCE_O2
+int LZ4_decompress_safe_partial_forceExtDict(const char* source, char* dest,
+                                     int compressedSize, int targetOutputSize, int dstCapacity,
+                                     const void* dictStart, size_t dictSize)
+{
+    dstCapacity = MIN(targetOutputSize, dstCapacity);
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
+                                  partial_decode, usingExtDict,
+                                  (BYTE*)dest, (const BYTE*)dictStart, dictSize);
+}
+
+LZ4_FORCE_O2
+static int LZ4_decompress_fast_extDict(const char* source, char* dest, int originalSize,
+                                       const void* dictStart, size_t dictSize)
+{
+    return LZ4_decompress_unsafe_generic(
+                (const BYTE*)source, (BYTE*)dest, originalSize,
+                0, (const BYTE*)dictStart, dictSize);
+}
+
+/* The "double dictionary" mode, for use with e.g. ring buffers: the first part
+ * of the dictionary is passed as prefix, and the second via dictStart + dictSize.
+ * These routines are used only once, in LZ4_decompress_*_continue().
+ */
+LZ4_FORCE_INLINE
+int LZ4_decompress_safe_doubleDict(const char* source, char* dest, int compressedSize, int maxOutputSize,
+                                   size_t prefixSize, const void* dictStart, size_t dictSize)
+{
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
+                                  decode_full_block, usingExtDict,
+                                  (BYTE*)dest-prefixSize, (const BYTE*)dictStart, dictSize);
+}
+
+/*===== streaming decompression functions =====*/
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4_streamDecode_t* LZ4_createStreamDecode(void)
+{
+    LZ4_STATIC_ASSERT(sizeof(LZ4_streamDecode_t) >= sizeof(LZ4_streamDecode_t_internal));
+    return (LZ4_streamDecode_t*) ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
+}
+
+int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
+{
+    if (LZ4_stream == NULL) { return 0; }  /* support free on NULL */
+    FREEMEM(LZ4_stream);
+    return 0;
+}
+#endif
+
+/*! LZ4_setStreamDecode() :
+ *  Use this function to instruct where to find the dictionary.
+ *  This function is not necessary if previous data is still available where it was decoded.
+ *  Loading a size of 0 is allowed (same effect as no dictionary).
+ * @return : 1 if OK, 0 if error
+ */
+int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize)
+{
+    LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
+    lz4sd->prefixSize = (size_t)dictSize;
+    if (dictSize) {
+        assert(dictionary != NULL);
+        lz4sd->prefixEnd = (const BYTE*) dictionary + dictSize;
+    } else {
+        lz4sd->prefixEnd = (const BYTE*) dictionary;
+    }
+    lz4sd->externalDict = NULL;
+    lz4sd->extDictSize  = 0;
+    return 1;
+}
+
+/*! LZ4_decoderRingBufferSize() :
+ *  when setting a ring buffer for streaming decompression (optional scenario),
+ *  provides the minimum size of this ring buffer
+ *  to be compatible with any source respecting maxBlockSize condition.
+ *  Note : in a ring buffer scenario,
+ *  blocks are presumed decompressed next to each other.
+ *  When not enough space remains for next block (remainingSize < maxBlockSize),
+ *  decoding resumes from beginning of ring buffer.
+ * @return : minimum ring buffer size,
+ *           or 0 if there is an error (invalid maxBlockSize).
+ */
+int LZ4_decoderRingBufferSize(int maxBlockSize)
+{
+    if (maxBlockSize < 0) return 0;
+    if (maxBlockSize > LZ4_MAX_INPUT_SIZE) return 0;
+    if (maxBlockSize < 16) maxBlockSize = 16;
+    return LZ4_DECODER_RING_BUFFER_SIZE(maxBlockSize);
+}
+
+/*
+*_continue() :
+    These decoding functions allow decompression of multiple blocks in "streaming" mode.
+    Previously decoded blocks must still be available at the memory position where they were decoded.
+    If it's not possible, save the relevant part of decoded data into a safe buffer,
+    and indicate where it stands using LZ4_setStreamDecode()
+*/
+LZ4_FORCE_O2
+int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* source, char* dest, int compressedSize, int maxOutputSize)
+{
+    LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
+    int result;
+
+    if (lz4sd->prefixSize == 0) {
+        /* The first call, no dictionary yet. */
+        assert(lz4sd->extDictSize == 0);
+        result = LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize = (size_t)result;
+        lz4sd->prefixEnd = (BYTE*)dest + result;
+    } else if (lz4sd->prefixEnd == (BYTE*)dest) {
+        /* They're rolling the current segment. */
+        if (lz4sd->prefixSize >= 64 KB - 1)
+            result = LZ4_decompress_safe_withPrefix64k(source, dest, compressedSize, maxOutputSize);
+        else if (lz4sd->extDictSize == 0)
+            result = LZ4_decompress_safe_withSmallPrefix(source, dest, compressedSize, maxOutputSize,
+                                                         lz4sd->prefixSize);
+        else
+            result = LZ4_decompress_safe_doubleDict(source, dest, compressedSize, maxOutputSize,
+                                                    lz4sd->prefixSize, lz4sd->externalDict, lz4sd->extDictSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize += (size_t)result;
+        lz4sd->prefixEnd  += result;
+    } else {
+        /* The buffer wraps around, or they're switching to another buffer. */
+        lz4sd->extDictSize = lz4sd->prefixSize;
+        lz4sd->externalDict = lz4sd->prefixEnd - lz4sd->extDictSize;
+        result = LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize,
+                                                  lz4sd->externalDict, lz4sd->extDictSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize = (size_t)result;
+        lz4sd->prefixEnd  = (BYTE*)dest + result;
+    }
+
+    return result;
+}
+
+LZ4_FORCE_O2 int
+LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode,
+                        const char* source, char* dest, int originalSize)
+{
+    LZ4_streamDecode_t_internal* const lz4sd =
+        (assert(LZ4_streamDecode!=NULL), &LZ4_streamDecode->internal_donotuse);
+    int result;
+
+    DEBUGLOG(5, "LZ4_decompress_fast_continue (toDecodeSize=%i)", originalSize);
+    assert(originalSize >= 0);
+
+    if (lz4sd->prefixSize == 0) {
+        DEBUGLOG(5, "first invocation : no prefix nor extDict");
+        assert(lz4sd->extDictSize == 0);
+        result = LZ4_decompress_fast(source, dest, originalSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize = (size_t)originalSize;
+        lz4sd->prefixEnd = (BYTE*)dest + originalSize;
+    } else if (lz4sd->prefixEnd == (BYTE*)dest) {
+        DEBUGLOG(5, "continue using existing prefix");
+        result = LZ4_decompress_unsafe_generic(
+                        (const BYTE*)source, (BYTE*)dest, originalSize,
+                        lz4sd->prefixSize,
+                        lz4sd->externalDict, lz4sd->extDictSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize += (size_t)originalSize;
+        lz4sd->prefixEnd  += originalSize;
+    } else {
+        DEBUGLOG(5, "prefix becomes extDict");
+        lz4sd->extDictSize = lz4sd->prefixSize;
+        lz4sd->externalDict = lz4sd->prefixEnd - lz4sd->extDictSize;
+        result = LZ4_decompress_fast_extDict(source, dest, originalSize,
+                                             lz4sd->externalDict, lz4sd->extDictSize);
+        if (result <= 0) return result;
+        lz4sd->prefixSize = (size_t)originalSize;
+        lz4sd->prefixEnd  = (BYTE*)dest + originalSize;
+    }
+
+    return result;
+}
+
+
+/*
+Advanced decoding functions :
+*_usingDict() :
+    These decoding functions work the same as "_continue" ones,
+    the dictionary must be explicitly provided within parameters
+*/
+
+int LZ4_decompress_safe_usingDict(const char* source, char* dest, int compressedSize, int maxOutputSize, const char* dictStart, int dictSize)
+{
+    if (dictSize==0)
+        return LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
+    if (dictStart+dictSize == dest) {
+        if (dictSize >= 64 KB - 1) {
+            return LZ4_decompress_safe_withPrefix64k(source, dest, compressedSize, maxOutputSize);
+        }
+        assert(dictSize >= 0);
+        return LZ4_decompress_safe_withSmallPrefix(source, dest, compressedSize, maxOutputSize, (size_t)dictSize);
+    }
+    assert(dictSize >= 0);
+    return LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize, dictStart, (size_t)dictSize);
+}
+
+int LZ4_decompress_safe_partial_usingDict(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity, const char* dictStart, int dictSize)
+{
+    if (dictSize==0)
+        return LZ4_decompress_safe_partial(source, dest, compressedSize, targetOutputSize, dstCapacity);
+    if (dictStart+dictSize == dest) {
+        if (dictSize >= 64 KB - 1) {
+            return LZ4_decompress_safe_partial_withPrefix64k(source, dest, compressedSize, targetOutputSize, dstCapacity);
+        }
+        assert(dictSize >= 0);
+        return LZ4_decompress_safe_partial_withSmallPrefix(source, dest, compressedSize, targetOutputSize, dstCapacity, (size_t)dictSize);
+    }
+    assert(dictSize >= 0);
+    return LZ4_decompress_safe_partial_forceExtDict(source, dest, compressedSize, targetOutputSize, dstCapacity, dictStart, (size_t)dictSize);
+}
+
+int LZ4_decompress_fast_usingDict(const char* source, char* dest, int originalSize, const char* dictStart, int dictSize)
+{
+    if (dictSize==0 || dictStart+dictSize == dest)
+        return LZ4_decompress_unsafe_generic(
+                        (const BYTE*)source, (BYTE*)dest, originalSize,
+                        (size_t)dictSize, NULL, 0);
+    assert(dictSize >= 0);
+    return LZ4_decompress_fast_extDict(source, dest, originalSize, dictStart, (size_t)dictSize);
+}
+
+
+/*=*************************************************
+*  Obsolete Functions
+***************************************************/
+/* obsolete compression functions */
+int LZ4_compress_limitedOutput(const char* source, char* dest, int inputSize, int maxOutputSize)
+{
+    return LZ4_compress_default(source, dest, inputSize, maxOutputSize);
+}
+int LZ4_compress(const char* src, char* dest, int srcSize)
+{
+    return LZ4_compress_default(src, dest, srcSize, LZ4_compressBound(srcSize));
+}
+int LZ4_compress_limitedOutput_withState (void* state, const char* src, char* dst, int srcSize, int dstSize)
+{
+    return LZ4_compress_fast_extState(state, src, dst, srcSize, dstSize, 1);
+}
+int LZ4_compress_withState (void* state, const char* src, char* dst, int srcSize)
+{
+    return LZ4_compress_fast_extState(state, src, dst, srcSize, LZ4_compressBound(srcSize), 1);
+}
+int LZ4_compress_limitedOutput_continue (LZ4_stream_t* LZ4_stream, const char* src, char* dst, int srcSize, int dstCapacity)
+{
+    return LZ4_compress_fast_continue(LZ4_stream, src, dst, srcSize, dstCapacity, 1);
+}
+int LZ4_compress_continue (LZ4_stream_t* LZ4_stream, const char* source, char* dest, int inputSize)
+{
+    return LZ4_compress_fast_continue(LZ4_stream, source, dest, inputSize, LZ4_compressBound(inputSize), 1);
+}
+
+/*
+These decompression functions are deprecated and should no longer be used.
+They are only provided here for compatibility with older user programs.
+- LZ4_uncompress is totally equivalent to LZ4_decompress_fast
+- LZ4_uncompress_unknownOutputSize is totally equivalent to LZ4_decompress_safe
+*/
+int LZ4_uncompress (const char* source, char* dest, int outputSize)
+{
+    return LZ4_decompress_fast(source, dest, outputSize);
+}
+int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize, int maxOutputSize)
+{
+    return LZ4_decompress_safe(source, dest, isize, maxOutputSize);
+}
+
+/* Obsolete Streaming functions */
+
+int LZ4_sizeofStreamState(void) { return sizeof(LZ4_stream_t); }
+
+int LZ4_resetStreamState(void* state, char* inputBuffer)
+{
+    (void)inputBuffer;
+    LZ4_resetStream((LZ4_stream_t*)state);
+    return 0;
+}
+
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+void* LZ4_create (char* inputBuffer)
+{
+    (void)inputBuffer;
+    return LZ4_createStream();
+}
+#endif
+
+char* LZ4_slideInputBuffer (void* state)
+{
+    /* avoid const char * -> char * conversion warning */
+    return (char *)(uptrval)((LZ4_stream_t*)state)->internal_donotuse.dictionary;
+}
+
+#endif   /* LZ4_COMMONDEFS_ONLY */

--- a/compress/third_party/lz4/lz4.h
+++ b/compress/third_party/lz4/lz4.h
@@ -1,0 +1,884 @@
+/*
+ *  LZ4 - Fast LZ compression algorithm
+ *  Header File
+ *  Copyright (C) 2011-2023, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+    - LZ4 homepage : http://www.lz4.org
+    - LZ4 source repository : https://github.com/lz4/lz4
+*/
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#ifndef LZ4_H_2983827168210
+#define LZ4_H_2983827168210
+
+/* --- Dependency --- */
+#include <stddef.h>   /* size_t */
+
+
+/**
+  Introduction
+
+  LZ4 is lossless compression algorithm, providing compression speed >500 MB/s per core,
+  scalable with multi-cores CPU. It features an extremely fast decoder, with speed in
+  multiple GB/s per core, typically reaching RAM speed limits on multi-core systems.
+
+  The LZ4 compression library provides in-memory compression and decompression functions.
+  It gives full buffer control to user.
+  Compression can be done in:
+    - a single step (described as Simple Functions)
+    - a single step, reusing a context (described in Advanced Functions)
+    - unbounded multiple steps (described as Streaming compression)
+
+  lz4.h generates and decodes LZ4-compressed blocks (doc/lz4_Block_format.md).
+  Decompressing such a compressed block requires additional metadata.
+  Exact metadata depends on exact decompression function.
+  For the typical case of LZ4_decompress_safe(),
+  metadata includes block's compressed size, and maximum bound of decompressed size.
+  Each application is free to encode and pass such metadata in whichever way it wants.
+
+  lz4.h only handle blocks, it can not generate Frames.
+
+  Blocks are different from Frames (doc/lz4_Frame_format.md).
+  Frames bundle both blocks and metadata in a specified manner.
+  Embedding metadata is required for compressed data to be self-contained and portable.
+  Frame format is delivered through a companion API, declared in lz4frame.h.
+  The `lz4` CLI can only manage frames.
+*/
+
+/*^***************************************************************
+*  Export parameters
+*****************************************************************/
+/*
+*  LZ4_DLL_EXPORT :
+*  Enable exporting of functions when building a Windows DLL
+*  LZ4LIB_VISIBILITY :
+*  Control library symbols visibility.
+*/
+#ifndef LZ4LIB_VISIBILITY
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LZ4LIB_VISIBILITY __attribute__ ((visibility ("default")))
+#  else
+#    define LZ4LIB_VISIBILITY
+#  endif
+#endif
+#if defined(LZ4_DLL_EXPORT) && (LZ4_DLL_EXPORT==1)
+#  define LZ4LIB_API __declspec(dllexport) LZ4LIB_VISIBILITY
+#elif defined(LZ4_DLL_IMPORT) && (LZ4_DLL_IMPORT==1)
+#  define LZ4LIB_API __declspec(dllimport) LZ4LIB_VISIBILITY /* It isn't required but allows to generate better code, saving a function pointer load from the IAT and an indirect jump.*/
+#else
+#  define LZ4LIB_API LZ4LIB_VISIBILITY
+#endif
+
+/*! LZ4_FREESTANDING :
+ *  When this macro is set to 1, it enables "freestanding mode" that is
+ *  suitable for typical freestanding environment which doesn't support
+ *  standard C library.
+ *
+ *  - LZ4_FREESTANDING is a compile-time switch.
+ *  - It requires the following macros to be defined:
+ *    LZ4_memcpy, LZ4_memmove, LZ4_memset.
+ *  - It only enables LZ4/HC functions which don't use heap.
+ *    All LZ4F_* functions are not supported.
+ *  - See tests/freestanding.c to check its basic setup.
+ */
+#if defined(LZ4_FREESTANDING) && (LZ4_FREESTANDING == 1)
+#  define LZ4_HEAPMODE 0
+#  define LZ4HC_HEAPMODE 0
+#  define LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION 1
+#  if !defined(LZ4_memcpy)
+#    error "LZ4_FREESTANDING requires macro 'LZ4_memcpy'."
+#  endif
+#  if !defined(LZ4_memset)
+#    error "LZ4_FREESTANDING requires macro 'LZ4_memset'."
+#  endif
+#  if !defined(LZ4_memmove)
+#    error "LZ4_FREESTANDING requires macro 'LZ4_memmove'."
+#  endif
+#elif ! defined(LZ4_FREESTANDING)
+#  define LZ4_FREESTANDING 0
+#endif
+
+
+/*------   Version   ------*/
+#define LZ4_VERSION_MAJOR    1    /* for breaking interface changes  */
+#define LZ4_VERSION_MINOR   10    /* for new (non-breaking) interface capabilities */
+#define LZ4_VERSION_RELEASE  0    /* for tweaks, bug-fixes, or development */
+
+#define LZ4_VERSION_NUMBER (LZ4_VERSION_MAJOR *100*100 + LZ4_VERSION_MINOR *100 + LZ4_VERSION_RELEASE)
+
+#define LZ4_LIB_VERSION LZ4_VERSION_MAJOR.LZ4_VERSION_MINOR.LZ4_VERSION_RELEASE
+#define LZ4_QUOTE(str) #str
+#define LZ4_EXPAND_AND_QUOTE(str) LZ4_QUOTE(str)
+#define LZ4_VERSION_STRING LZ4_EXPAND_AND_QUOTE(LZ4_LIB_VERSION)  /* requires v1.7.3+ */
+
+LZ4LIB_API int LZ4_versionNumber (void);  /**< library version number; useful to check dll version; requires v1.3.0+ */
+LZ4LIB_API const char* LZ4_versionString (void);   /**< library version string; useful to check dll version; requires v1.7.5+ */
+
+
+/*-************************************
+*  Tuning memory usage
+**************************************/
+/*!
+ * LZ4_MEMORY_USAGE :
+ * Can be selected at compile time, by setting LZ4_MEMORY_USAGE.
+ * Memory usage formula : N->2^N Bytes (examples : 10 -> 1KB; 12 -> 4KB ; 16 -> 64KB; 20 -> 1MB)
+ * Increasing memory usage improves compression ratio, generally at the cost of speed.
+ * Reduced memory usage may improve speed at the cost of ratio, thanks to better cache locality.
+ * Default value is 14, for 16KB, which nicely fits into most L1 caches.
+ */
+#ifndef LZ4_MEMORY_USAGE
+# define LZ4_MEMORY_USAGE LZ4_MEMORY_USAGE_DEFAULT
+#endif
+
+/* These are absolute limits, they should not be changed by users */
+#define LZ4_MEMORY_USAGE_MIN 10
+#define LZ4_MEMORY_USAGE_DEFAULT 14
+#define LZ4_MEMORY_USAGE_MAX 20
+
+#if (LZ4_MEMORY_USAGE < LZ4_MEMORY_USAGE_MIN)
+#  error "LZ4_MEMORY_USAGE is too small !"
+#endif
+
+#if (LZ4_MEMORY_USAGE > LZ4_MEMORY_USAGE_MAX)
+#  error "LZ4_MEMORY_USAGE is too large !"
+#endif
+
+/*-************************************
+*  Simple Functions
+**************************************/
+/*! LZ4_compress_default() :
+ *  Compresses 'srcSize' bytes from buffer 'src'
+ *  into already allocated 'dst' buffer of size 'dstCapacity'.
+ *  Compression is guaranteed to succeed if 'dstCapacity' >= LZ4_compressBound(srcSize).
+ *  It also runs faster, so it's a recommended setting.
+ *  If the function cannot compress 'src' into a more limited 'dst' budget,
+ *  compression stops *immediately*, and the function result is zero.
+ *  In which case, 'dst' content is undefined (invalid).
+ *      srcSize : max supported value is LZ4_MAX_INPUT_SIZE.
+ *      dstCapacity : size of buffer 'dst' (which must be already allocated)
+ *     @return  : the number of bytes written into buffer 'dst' (necessarily <= dstCapacity)
+ *                or 0 if compression fails
+ * Note : This function is protected against buffer overflow scenarios (never writes outside 'dst' buffer, nor read outside 'source' buffer).
+ */
+LZ4LIB_API int LZ4_compress_default(const char* src, char* dst, int srcSize, int dstCapacity);
+
+/*! LZ4_decompress_safe() :
+ * @compressedSize : is the exact complete size of the compressed block.
+ * @dstCapacity : is the size of destination buffer (which must be already allocated),
+ *                presumed an upper bound of decompressed size.
+ * @return : the number of bytes decompressed into destination buffer (necessarily <= dstCapacity)
+ *           If destination buffer is not large enough, decoding will stop and output an error code (negative value).
+ *           If the source stream is detected malformed, the function will stop decoding and return a negative result.
+ * Note 1 : This function is protected against malicious data packets :
+ *          it will never writes outside 'dst' buffer, nor read outside 'source' buffer,
+ *          even if the compressed block is maliciously modified to order the decoder to do these actions.
+ *          In such case, the decoder stops immediately, and considers the compressed block malformed.
+ * Note 2 : compressedSize and dstCapacity must be provided to the function, the compressed block does not contain them.
+ *          The implementation is free to send / store / derive this information in whichever way is most beneficial.
+ *          If there is a need for a different format which bundles together both compressed data and its metadata, consider looking at lz4frame.h instead.
+ */
+LZ4LIB_API int LZ4_decompress_safe (const char* src, char* dst, int compressedSize, int dstCapacity);
+
+
+/*-************************************
+*  Advanced Functions
+**************************************/
+#define LZ4_MAX_INPUT_SIZE        0x7E000000   /* 2 113 929 216 bytes */
+#define LZ4_COMPRESSBOUND(isize)  ((unsigned)(isize) > (unsigned)LZ4_MAX_INPUT_SIZE ? 0 : (isize) + ((isize)/255) + 16)
+
+/*! LZ4_compressBound() :
+    Provides the maximum size that LZ4 compression may output in a "worst case" scenario (input data not compressible)
+    This function is primarily useful for memory allocation purposes (destination buffer size).
+    Macro LZ4_COMPRESSBOUND() is also provided for compilation-time evaluation (stack memory allocation for example).
+    Note that LZ4_compress_default() compresses faster when dstCapacity is >= LZ4_compressBound(srcSize)
+        inputSize  : max supported value is LZ4_MAX_INPUT_SIZE
+        return : maximum output size in a "worst case" scenario
+              or 0, if input size is incorrect (too large or negative)
+*/
+LZ4LIB_API int LZ4_compressBound(int inputSize);
+
+/*! LZ4_compress_fast() :
+    Same as LZ4_compress_default(), but allows selection of "acceleration" factor.
+    The larger the acceleration value, the faster the algorithm, but also the lesser the compression.
+    It's a trade-off. It can be fine tuned, with each successive value providing roughly +~3% to speed.
+    An acceleration value of "1" is the same as regular LZ4_compress_default()
+    Values <= 0 will be replaced by LZ4_ACCELERATION_DEFAULT (currently == 1, see lz4.c).
+    Values > LZ4_ACCELERATION_MAX will be replaced by LZ4_ACCELERATION_MAX (currently == 65537, see lz4.c).
+*/
+LZ4LIB_API int LZ4_compress_fast (const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+
+/*! LZ4_compress_fast_extState() :
+ *  Same as LZ4_compress_fast(), using an externally allocated memory space for its state.
+ *  Use LZ4_sizeofState() to know how much memory must be allocated,
+ *  and allocate it on 8-bytes boundaries (using `malloc()` typically).
+ *  Then, provide this buffer as `void* state` to compression function.
+ */
+LZ4LIB_API int LZ4_sizeofState(void);
+LZ4LIB_API int LZ4_compress_fast_extState (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+/*! LZ4_compress_destSize() :
+ *  Reverse the logic : compresses as much data as possible from 'src' buffer
+ *  into already allocated buffer 'dst', of size >= 'dstCapacity'.
+ *  This function either compresses the entire 'src' content into 'dst' if it's large enough,
+ *  or fill 'dst' buffer completely with as much data as possible from 'src'.
+ *  note: acceleration parameter is fixed to "default".
+ *
+ * *srcSizePtr : in+out parameter. Initially contains size of input.
+ *               Will be modified to indicate how many bytes where read from 'src' to fill 'dst'.
+ *               New value is necessarily <= input value.
+ * @return : Nb bytes written into 'dst' (necessarily <= dstCapacity)
+ *           or 0 if compression fails.
+ *
+ * Note : from v1.8.2 to v1.9.1, this function had a bug (fixed in v1.9.2+):
+ *        the produced compressed content could, in specific circumstances,
+ *        require to be decompressed into a destination buffer larger
+ *        by at least 1 byte than the content to decompress.
+ *        If an application uses `LZ4_compress_destSize()`,
+ *        it's highly recommended to update liblz4 to v1.9.2 or better.
+ *        If this can't be done or ensured,
+ *        the receiving decompression function should provide
+ *        a dstCapacity which is > decompressedSize, by at least 1 byte.
+ *        See https://github.com/lz4/lz4/issues/859 for details
+ */
+LZ4LIB_API int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targetDstSize);
+
+/*! LZ4_decompress_safe_partial() :
+ *  Decompress an LZ4 compressed block, of size 'srcSize' at position 'src',
+ *  into destination buffer 'dst' of size 'dstCapacity'.
+ *  Up to 'targetOutputSize' bytes will be decoded.
+ *  The function stops decoding on reaching this objective.
+ *  This can be useful to boost performance
+ *  whenever only the beginning of a block is required.
+ *
+ * @return : the number of bytes decoded in `dst` (necessarily <= targetOutputSize)
+ *           If source stream is detected malformed, function returns a negative result.
+ *
+ *  Note 1 : @return can be < targetOutputSize, if compressed block contains less data.
+ *
+ *  Note 2 : targetOutputSize must be <= dstCapacity
+ *
+ *  Note 3 : this function effectively stops decoding on reaching targetOutputSize,
+ *           so dstCapacity is kind of redundant.
+ *           This is because in older versions of this function,
+ *           decoding operation would still write complete sequences.
+ *           Therefore, there was no guarantee that it would stop writing at exactly targetOutputSize,
+ *           it could write more bytes, though only up to dstCapacity.
+ *           Some "margin" used to be required for this operation to work properly.
+ *           Thankfully, this is no longer necessary.
+ *           The function nonetheless keeps the same signature, in an effort to preserve API compatibility.
+ *
+ *  Note 4 : If srcSize is the exact size of the block,
+ *           then targetOutputSize can be any value,
+ *           including larger than the block's decompressed size.
+ *           The function will, at most, generate block's decompressed size.
+ *
+ *  Note 5 : If srcSize is _larger_ than block's compressed size,
+ *           then targetOutputSize **MUST** be <= block's decompressed size.
+ *           Otherwise, *silent corruption will occur*.
+ */
+LZ4LIB_API int LZ4_decompress_safe_partial (const char* src, char* dst, int srcSize, int targetOutputSize, int dstCapacity);
+
+
+/*-*********************************************
+*  Streaming Compression Functions
+***********************************************/
+typedef union LZ4_stream_u LZ4_stream_t;  /* incomplete type (defined later) */
+
+/*!
+ Note about RC_INVOKED
+
+ - RC_INVOKED is predefined symbol of rc.exe (the resource compiler which is part of MSVC/Visual Studio).
+   https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros
+
+ - Since rc.exe is a legacy compiler, it truncates long symbol (> 30 chars)
+   and reports warning "RC4011: identifier truncated".
+
+ - To eliminate the warning, we surround long preprocessor symbol with
+   "#if !defined(RC_INVOKED) ... #endif" block that means
+   "skip this block when rc.exe is trying to read it".
+*/
+#if !defined(RC_INVOKED) /* https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros */
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4LIB_API LZ4_stream_t* LZ4_createStream(void);
+LZ4LIB_API int           LZ4_freeStream (LZ4_stream_t* streamPtr);
+#endif /* !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION) */
+#endif
+
+/*! LZ4_resetStream_fast() : v1.9.0+
+ *  Use this to prepare an LZ4_stream_t for a new chain of dependent blocks
+ *  (e.g., LZ4_compress_fast_continue()).
+ *
+ *  An LZ4_stream_t must be initialized once before usage.
+ *  This is automatically done when created by LZ4_createStream().
+ *  However, should the LZ4_stream_t be simply declared on stack (for example),
+ *  it's necessary to initialize it first, using LZ4_initStream().
+ *
+ *  After init, start any new stream with LZ4_resetStream_fast().
+ *  A same LZ4_stream_t can be re-used multiple times consecutively
+ *  and compress multiple streams,
+ *  provided that it starts each new stream with LZ4_resetStream_fast().
+ *
+ *  LZ4_resetStream_fast() is much faster than LZ4_initStream(),
+ *  but is not compatible with memory regions containing garbage data.
+ *
+ *  Note: it's only useful to call LZ4_resetStream_fast()
+ *        in the context of streaming compression.
+ *        The *extState* functions perform their own resets.
+ *        Invoking LZ4_resetStream_fast() before is redundant, and even counterproductive.
+ */
+LZ4LIB_API void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
+
+/*! LZ4_loadDict() :
+ *  Use this function to reference a static dictionary into LZ4_stream_t.
+ *  The dictionary must remain available during compression.
+ *  LZ4_loadDict() triggers a reset, so any previous data will be forgotten.
+ *  The same dictionary will have to be loaded on decompression side for successful decoding.
+ *  Dictionary are useful for better compression of small data (KB range).
+ *  While LZ4 itself accepts any input as dictionary, dictionary efficiency is also a topic.
+ *  When in doubt, employ the Zstandard's Dictionary Builder.
+ *  Loading a size of 0 is allowed, and is the same as reset.
+ * @return : loaded dictionary size, in bytes (note: only the last 64 KB are loaded)
+ */
+LZ4LIB_API int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
+
+/*! LZ4_loadDictSlow() : v1.10.0+
+ *  Same as LZ4_loadDict(),
+ *  but uses a bit more cpu to reference the dictionary content more thoroughly.
+ *  This is expected to slightly improve compression ratio.
+ *  The extra-cpu cost is likely worth it if the dictionary is re-used across multiple sessions.
+ * @return : loaded dictionary size, in bytes (note: only the last 64 KB are loaded)
+ */
+LZ4LIB_API int LZ4_loadDictSlow(LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
+
+/*! LZ4_attach_dictionary() : stable since v1.10.0
+ *
+ *  This allows efficient re-use of a static dictionary multiple times.
+ *
+ *  Rather than re-loading the dictionary buffer into a working context before
+ *  each compression, or copying a pre-loaded dictionary's LZ4_stream_t into a
+ *  working LZ4_stream_t, this function introduces a no-copy setup mechanism,
+ *  in which the working stream references @dictionaryStream in-place.
+ *
+ *  Several assumptions are made about the state of @dictionaryStream.
+ *  Currently, only states which have been prepared by LZ4_loadDict() or
+ *  LZ4_loadDictSlow() should be expected to work.
+ *
+ *  Alternatively, the provided @dictionaryStream may be NULL,
+ *  in which case any existing dictionary stream is unset.
+ *
+ *  If a dictionary is provided, it replaces any pre-existing stream history.
+ *  The dictionary contents are the only history that can be referenced and
+ *  logically immediately precede the data compressed in the first subsequent
+ *  compression call.
+ *
+ *  The dictionary will only remain attached to the working stream through the
+ *  first compression call, at the end of which it is cleared.
+ * @dictionaryStream stream (and source buffer) must remain in-place / accessible / unchanged
+ *  through the completion of the compression session.
+ *
+ *  Note: there is no equivalent LZ4_attach_*() method on the decompression side
+ *  because there is no initialization cost, hence no need to share the cost across multiple sessions.
+ *  To decompress LZ4 blocks using dictionary, attached or not,
+ *  just employ the regular LZ4_setStreamDecode() for streaming,
+ *  or the stateless LZ4_decompress_safe_usingDict() for one-shot decompression.
+ */
+LZ4LIB_API void
+LZ4_attach_dictionary(LZ4_stream_t* workingStream,
+                const LZ4_stream_t* dictionaryStream);
+
+/*! LZ4_compress_fast_continue() :
+ *  Compress 'src' content using data from previously compressed blocks, for better compression ratio.
+ * 'dst' buffer must be already allocated.
+ *  If dstCapacity >= LZ4_compressBound(srcSize), compression is guaranteed to succeed, and runs faster.
+ *
+ * @return : size of compressed block
+ *           or 0 if there is an error (typically, cannot fit into 'dst').
+ *
+ *  Note 1 : Each invocation to LZ4_compress_fast_continue() generates a new block.
+ *           Each block has precise boundaries.
+ *           Each block must be decompressed separately, calling LZ4_decompress_*() with relevant metadata.
+ *           It's not possible to append blocks together and expect a single invocation of LZ4_decompress_*() to decompress them together.
+ *
+ *  Note 2 : The previous 64KB of source data is __assumed__ to remain present, unmodified, at same address in memory !
+ *
+ *  Note 3 : When input is structured as a double-buffer, each buffer can have any size, including < 64 KB.
+ *           Make sure that buffers are separated, by at least one byte.
+ *           This construction ensures that each block only depends on previous block.
+ *
+ *  Note 4 : If input buffer is a ring-buffer, it can have any size, including < 64 KB.
+ *
+ *  Note 5 : After an error, the stream status is undefined (invalid), it can only be reset or freed.
+ */
+LZ4LIB_API int LZ4_compress_fast_continue (LZ4_stream_t* streamPtr, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+/*! LZ4_saveDict() :
+ *  If last 64KB data cannot be guaranteed to remain available at its current memory location,
+ *  save it into a safer place (char* safeBuffer).
+ *  This is schematically equivalent to a memcpy() followed by LZ4_loadDict(),
+ *  but is much faster, because LZ4_saveDict() doesn't need to rebuild tables.
+ * @return : saved dictionary size in bytes (necessarily <= maxDictSize), or 0 if error.
+ */
+LZ4LIB_API int LZ4_saveDict (LZ4_stream_t* streamPtr, char* safeBuffer, int maxDictSize);
+
+
+/*-**********************************************
+*  Streaming Decompression Functions
+*  Bufferless synchronous API
+************************************************/
+typedef union LZ4_streamDecode_u LZ4_streamDecode_t;   /* tracking context */
+
+/*! LZ4_createStreamDecode() and LZ4_freeStreamDecode() :
+ *  creation / destruction of streaming decompression tracking context.
+ *  A tracking context can be re-used multiple times.
+ */
+#if !defined(RC_INVOKED) /* https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros */
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4LIB_API LZ4_streamDecode_t* LZ4_createStreamDecode(void);
+LZ4LIB_API int                 LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream);
+#endif /* !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION) */
+#endif
+
+/*! LZ4_setStreamDecode() :
+ *  An LZ4_streamDecode_t context can be allocated once and re-used multiple times.
+ *  Use this function to start decompression of a new stream of blocks.
+ *  A dictionary can optionally be set. Use NULL or size 0 for a reset order.
+ *  Dictionary is presumed stable : it must remain accessible and unmodified during next decompression.
+ * @return : 1 if OK, 0 if error
+ */
+LZ4LIB_API int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize);
+
+/*! LZ4_decoderRingBufferSize() : v1.8.2+
+ *  Note : in a ring buffer scenario (optional),
+ *  blocks are presumed decompressed next to each other
+ *  up to the moment there is not enough remaining space for next block (remainingSize < maxBlockSize),
+ *  at which stage it resumes from beginning of ring buffer.
+ *  When setting such a ring buffer for streaming decompression,
+ *  provides the minimum size of this ring buffer
+ *  to be compatible with any source respecting maxBlockSize condition.
+ * @return : minimum ring buffer size,
+ *           or 0 if there is an error (invalid maxBlockSize).
+ */
+LZ4LIB_API int LZ4_decoderRingBufferSize(int maxBlockSize);
+#define LZ4_DECODER_RING_BUFFER_SIZE(maxBlockSize) (65536 + 14 + (maxBlockSize))  /* for static allocation; maxBlockSize presumed valid */
+
+/*! LZ4_decompress_safe_continue() :
+ *  This decoding function allows decompression of consecutive blocks in "streaming" mode.
+ *  The difference with the usual independent blocks is that
+ *  new blocks are allowed to find references into former blocks.
+ *  A block is an unsplittable entity, and must be presented entirely to the decompression function.
+ *  LZ4_decompress_safe_continue() only accepts one block at a time.
+ *  It's modeled after `LZ4_decompress_safe()` and behaves similarly.
+ *
+ * @LZ4_streamDecode : decompression state, tracking the position in memory of past data
+ * @compressedSize : exact complete size of one compressed block.
+ * @dstCapacity : size of destination buffer (which must be already allocated),
+ *                must be an upper bound of decompressed size.
+ * @return : number of bytes decompressed into destination buffer (necessarily <= dstCapacity)
+ *           If destination buffer is not large enough, decoding will stop and output an error code (negative value).
+ *           If the source stream is detected malformed, the function will stop decoding and return a negative result.
+ *
+ *  The last 64KB of previously decoded data *must* remain available and unmodified
+ *  at the memory position where they were previously decoded.
+ *  If less than 64KB of data has been decoded, all the data must be present.
+ *
+ *  Special : if decompression side sets a ring buffer, it must respect one of the following conditions :
+ *  - Decompression buffer size is _at least_ LZ4_decoderRingBufferSize(maxBlockSize).
+ *    maxBlockSize is the maximum size of any single block. It can have any value > 16 bytes.
+ *    In which case, encoding and decoding buffers do not need to be synchronized.
+ *    Actually, data can be produced by any source compliant with LZ4 format specification, and respecting maxBlockSize.
+ *  - Synchronized mode :
+ *    Decompression buffer size is _exactly_ the same as compression buffer size,
+ *    and follows exactly same update rule (block boundaries at same positions),
+ *    and decoding function is provided with exact decompressed size of each block (exception for last block of the stream),
+ *    _then_ decoding & encoding ring buffer can have any size, including small ones ( < 64 KB).
+ *  - Decompression buffer is larger than encoding buffer, by a minimum of maxBlockSize more bytes.
+ *    In which case, encoding and decoding buffers do not need to be synchronized,
+ *    and encoding ring buffer can have any size, including small ones ( < 64 KB).
+ *
+ *  Whenever these conditions are not possible,
+ *  save the last 64KB of decoded data into a safe buffer where it can't be modified during decompression,
+ *  then indicate where this data is saved using LZ4_setStreamDecode(), before decompressing next block.
+*/
+LZ4LIB_API int
+LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode,
+                        const char* src, char* dst,
+                        int srcSize, int dstCapacity);
+
+
+/*! LZ4_decompress_safe_usingDict() :
+ *  Works the same as
+ *  a combination of LZ4_setStreamDecode() followed by LZ4_decompress_safe_continue()
+ *  However, it's stateless: it doesn't need any LZ4_streamDecode_t state.
+ *  Dictionary is presumed stable : it must remain accessible and unmodified during decompression.
+ *  Performance tip : Decompression speed can be substantially increased
+ *                    when dst == dictStart + dictSize.
+ */
+LZ4LIB_API int
+LZ4_decompress_safe_usingDict(const char* src, char* dst,
+                              int srcSize, int dstCapacity,
+                              const char* dictStart, int dictSize);
+
+/*! LZ4_decompress_safe_partial_usingDict() :
+ *  Behaves the same as LZ4_decompress_safe_partial()
+ *  with the added ability to specify a memory segment for past data.
+ *  Performance tip : Decompression speed can be substantially increased
+ *                    when dst == dictStart + dictSize.
+ */
+LZ4LIB_API int
+LZ4_decompress_safe_partial_usingDict(const char* src, char* dst,
+                                      int compressedSize,
+                                      int targetOutputSize, int maxOutputSize,
+                                      const char* dictStart, int dictSize);
+
+#endif /* LZ4_H_2983827168210 */
+
+
+/*^*************************************
+ * !!!!!!   STATIC LINKING ONLY   !!!!!!
+ ***************************************/
+
+/*-****************************************************************************
+ * Experimental section
+ *
+ * Symbols declared in this section must be considered unstable. Their
+ * signatures or semantics may change, or they may be removed altogether in the
+ * future. They are therefore only safe to depend on when the caller is
+ * statically linked against the library.
+ *
+ * To protect against unsafe usage, not only are the declarations guarded,
+ * the definitions are hidden by default
+ * when building LZ4 as a shared/dynamic library.
+ *
+ * In order to access these declarations,
+ * define LZ4_STATIC_LINKING_ONLY in your application
+ * before including LZ4's headers.
+ *
+ * In order to make their implementations accessible dynamically, you must
+ * define LZ4_PUBLISH_STATIC_FUNCTIONS when building the LZ4 library.
+ ******************************************************************************/
+
+#ifdef LZ4_STATIC_LINKING_ONLY
+
+#ifndef LZ4_STATIC_3504398509
+#define LZ4_STATIC_3504398509
+
+#ifdef LZ4_PUBLISH_STATIC_FUNCTIONS
+# define LZ4LIB_STATIC_API LZ4LIB_API
+#else
+# define LZ4LIB_STATIC_API
+#endif
+
+
+/*! LZ4_compress_fast_extState_fastReset() :
+ *  A variant of LZ4_compress_fast_extState().
+ *
+ *  Using this variant avoids an expensive initialization step.
+ *  It is only safe to call if the state buffer is known to be correctly initialized already
+ *  (see above comment on LZ4_resetStream_fast() for a definition of "correctly initialized").
+ *  From a high level, the difference is that
+ *  this function initializes the provided state with a call to something like LZ4_resetStream_fast()
+ *  while LZ4_compress_fast_extState() starts with a call to LZ4_resetStream().
+ */
+LZ4LIB_STATIC_API int LZ4_compress_fast_extState_fastReset (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+/*! LZ4_compress_destSize_extState() : introduced in v1.10.0
+ *  Same as LZ4_compress_destSize(), but using an externally allocated state.
+ *  Also: exposes @acceleration
+ */
+int LZ4_compress_destSize_extState(void* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration);
+
+/*! In-place compression and decompression
+ *
+ * It's possible to have input and output sharing the same buffer,
+ * for highly constrained memory environments.
+ * In both cases, it requires input to lay at the end of the buffer,
+ * and decompression to start at beginning of the buffer.
+ * Buffer size must feature some margin, hence be larger than final size.
+ *
+ * |<------------------------buffer--------------------------------->|
+ *                             |<-----------compressed data--------->|
+ * |<-----------decompressed size------------------>|
+ *                                                  |<----margin---->|
+ *
+ * This technique is more useful for decompression,
+ * since decompressed size is typically larger,
+ * and margin is short.
+ *
+ * In-place decompression will work inside any buffer
+ * which size is >= LZ4_DECOMPRESS_INPLACE_BUFFER_SIZE(decompressedSize).
+ * This presumes that decompressedSize > compressedSize.
+ * Otherwise, it means compression actually expanded data,
+ * and it would be more efficient to store such data with a flag indicating it's not compressed.
+ * This can happen when data is not compressible (already compressed, or encrypted).
+ *
+ * For in-place compression, margin is larger, as it must be able to cope with both
+ * history preservation, requiring input data to remain unmodified up to LZ4_DISTANCE_MAX,
+ * and data expansion, which can happen when input is not compressible.
+ * As a consequence, buffer size requirements are much higher,
+ * and memory savings offered by in-place compression are more limited.
+ *
+ * There are ways to limit this cost for compression :
+ * - Reduce history size, by modifying LZ4_DISTANCE_MAX.
+ *   Note that it is a compile-time constant, so all compressions will apply this limit.
+ *   Lower values will reduce compression ratio, except when input_size < LZ4_DISTANCE_MAX,
+ *   so it's a reasonable trick when inputs are known to be small.
+ * - Require the compressor to deliver a "maximum compressed size".
+ *   This is the `dstCapacity` parameter in `LZ4_compress*()`.
+ *   When this size is < LZ4_COMPRESSBOUND(inputSize), then compression can fail,
+ *   in which case, the return code will be 0 (zero).
+ *   The caller must be ready for these cases to happen,
+ *   and typically design a backup scheme to send data uncompressed.
+ * The combination of both techniques can significantly reduce
+ * the amount of margin required for in-place compression.
+ *
+ * In-place compression can work in any buffer
+ * which size is >= (maxCompressedSize)
+ * with maxCompressedSize == LZ4_COMPRESSBOUND(srcSize) for guaranteed compression success.
+ * LZ4_COMPRESS_INPLACE_BUFFER_SIZE() depends on both maxCompressedSize and LZ4_DISTANCE_MAX,
+ * so it's possible to reduce memory requirements by playing with them.
+ */
+
+#define LZ4_DECOMPRESS_INPLACE_MARGIN(compressedSize)          (((compressedSize) >> 8) + 32)
+#define LZ4_DECOMPRESS_INPLACE_BUFFER_SIZE(decompressedSize)   ((decompressedSize) + LZ4_DECOMPRESS_INPLACE_MARGIN(decompressedSize))  /**< note: presumes that compressedSize < decompressedSize. note2: margin is overestimated a bit, since it could use compressedSize instead */
+
+#ifndef LZ4_DISTANCE_MAX   /* history window size; can be user-defined at compile time */
+#  define LZ4_DISTANCE_MAX 65535   /* set to maximum value by default */
+#endif
+
+#define LZ4_COMPRESS_INPLACE_MARGIN                           (LZ4_DISTANCE_MAX + 32)   /* LZ4_DISTANCE_MAX can be safely replaced by srcSize when it's smaller */
+#define LZ4_COMPRESS_INPLACE_BUFFER_SIZE(maxCompressedSize)   ((maxCompressedSize) + LZ4_COMPRESS_INPLACE_MARGIN)  /**< maxCompressedSize is generally LZ4_COMPRESSBOUND(inputSize), but can be set to any lower value, with the risk that compression can fail (return code 0(zero)) */
+
+#endif   /* LZ4_STATIC_3504398509 */
+#endif   /* LZ4_STATIC_LINKING_ONLY */
+
+
+
+#ifndef LZ4_H_98237428734687
+#define LZ4_H_98237428734687
+
+/*-************************************************************
+ *  Private Definitions
+ **************************************************************
+ * Do not use these definitions directly.
+ * They are only exposed to allow static allocation of `LZ4_stream_t` and `LZ4_streamDecode_t`.
+ * Accessing members will expose user code to API and/or ABI break in future versions of the library.
+ **************************************************************/
+#define LZ4_HASHLOG   (LZ4_MEMORY_USAGE-2)
+#define LZ4_HASHTABLESIZE (1 << LZ4_MEMORY_USAGE)
+#define LZ4_HASH_SIZE_U32 (1 << LZ4_HASHLOG)       /* required as macro for static allocation */
+
+#if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+# include <stdint.h>
+  typedef  int8_t  LZ4_i8;
+  typedef uint8_t  LZ4_byte;
+  typedef uint16_t LZ4_u16;
+  typedef uint32_t LZ4_u32;
+#else
+  typedef   signed char  LZ4_i8;
+  typedef unsigned char  LZ4_byte;
+  typedef unsigned short LZ4_u16;
+  typedef unsigned int   LZ4_u32;
+#endif
+
+/*! LZ4_stream_t :
+ *  Never ever use below internal definitions directly !
+ *  These definitions are not API/ABI safe, and may change in future versions.
+ *  If you need static allocation, declare or allocate an LZ4_stream_t object.
+**/
+
+typedef struct LZ4_stream_t_internal LZ4_stream_t_internal;
+struct LZ4_stream_t_internal {
+    LZ4_u32 hashTable[LZ4_HASH_SIZE_U32];
+    const LZ4_byte* dictionary;
+    const LZ4_stream_t_internal* dictCtx;
+    LZ4_u32 currentOffset;
+    LZ4_u32 tableType;
+    LZ4_u32 dictSize;
+    /* Implicit padding to ensure structure is aligned */
+};
+
+#define LZ4_STREAM_MINSIZE  ((1UL << (LZ4_MEMORY_USAGE)) + 32)  /* static size, for inter-version compatibility */
+union LZ4_stream_u {
+    char minStateSize[LZ4_STREAM_MINSIZE];
+    LZ4_stream_t_internal internal_donotuse;
+}; /* previously typedef'd to LZ4_stream_t */
+
+
+/*! LZ4_initStream() : v1.9.0+
+ *  An LZ4_stream_t structure must be initialized at least once.
+ *  This is automatically done when invoking LZ4_createStream(),
+ *  but it's not when the structure is simply declared on stack (for example).
+ *
+ *  Use LZ4_initStream() to properly initialize a newly declared LZ4_stream_t.
+ *  It can also initialize any arbitrary buffer of sufficient size,
+ *  and will @return a pointer of proper type upon initialization.
+ *
+ *  Note : initialization fails if size and alignment conditions are not respected.
+ *         In which case, the function will @return NULL.
+ *  Note2: An LZ4_stream_t structure guarantees correct alignment and size.
+ *  Note3: Before v1.9.0, use LZ4_resetStream() instead
+**/
+LZ4LIB_API LZ4_stream_t* LZ4_initStream (void* stateBuffer, size_t size);
+
+
+/*! LZ4_streamDecode_t :
+ *  Never ever use below internal definitions directly !
+ *  These definitions are not API/ABI safe, and may change in future versions.
+ *  If you need static allocation, declare or allocate an LZ4_streamDecode_t object.
+**/
+typedef struct {
+    const LZ4_byte* externalDict;
+    const LZ4_byte* prefixEnd;
+    size_t extDictSize;
+    size_t prefixSize;
+} LZ4_streamDecode_t_internal;
+
+#define LZ4_STREAMDECODE_MINSIZE 32
+union LZ4_streamDecode_u {
+    char minStateSize[LZ4_STREAMDECODE_MINSIZE];
+    LZ4_streamDecode_t_internal internal_donotuse;
+} ;   /* previously typedef'd to LZ4_streamDecode_t */
+
+
+
+/*-************************************
+*  Obsolete Functions
+**************************************/
+
+/*! Deprecation warnings
+ *
+ *  Deprecated functions make the compiler generate a warning when invoked.
+ *  This is meant to invite users to update their source code.
+ *  Should deprecation warnings be a problem, it is generally possible to disable them,
+ *  typically with -Wno-deprecated-declarations for gcc
+ *  or _CRT_SECURE_NO_WARNINGS in Visual.
+ *
+ *  Another method is to define LZ4_DISABLE_DEPRECATE_WARNINGS
+ *  before including the header file.
+ */
+#ifdef LZ4_DISABLE_DEPRECATE_WARNINGS
+#  define LZ4_DEPRECATED(message)   /* disable deprecation warnings */
+#else
+#  if defined (__cplusplus) && (__cplusplus >= 201402) /* C++14 or greater */
+#    define LZ4_DEPRECATED(message) [[deprecated(message)]]
+#  elif defined(_MSC_VER)
+#    define LZ4_DEPRECATED(message) __declspec(deprecated(message))
+#  elif defined(__clang__) || (defined(__GNUC__) && (__GNUC__ * 10 + __GNUC_MINOR__ >= 45))
+#    define LZ4_DEPRECATED(message) __attribute__((deprecated(message)))
+#  elif defined(__GNUC__) && (__GNUC__ * 10 + __GNUC_MINOR__ >= 31)
+#    define LZ4_DEPRECATED(message) __attribute__((deprecated))
+#  else
+#    pragma message("WARNING: LZ4_DEPRECATED needs custom implementation for this compiler")
+#    define LZ4_DEPRECATED(message)   /* disabled */
+#  endif
+#endif /* LZ4_DISABLE_DEPRECATE_WARNINGS */
+
+/*! Obsolete compression functions (since v1.7.3) */
+LZ4_DEPRECATED("use LZ4_compress_default() instead")       LZ4LIB_API int LZ4_compress               (const char* src, char* dest, int srcSize);
+LZ4_DEPRECATED("use LZ4_compress_default() instead")       LZ4LIB_API int LZ4_compress_limitedOutput (const char* src, char* dest, int srcSize, int maxOutputSize);
+LZ4_DEPRECATED("use LZ4_compress_fast_extState() instead") LZ4LIB_API int LZ4_compress_withState               (void* state, const char* source, char* dest, int inputSize);
+LZ4_DEPRECATED("use LZ4_compress_fast_extState() instead") LZ4LIB_API int LZ4_compress_limitedOutput_withState (void* state, const char* source, char* dest, int inputSize, int maxOutputSize);
+LZ4_DEPRECATED("use LZ4_compress_fast_continue() instead") LZ4LIB_API int LZ4_compress_continue                (LZ4_stream_t* LZ4_streamPtr, const char* source, char* dest, int inputSize);
+LZ4_DEPRECATED("use LZ4_compress_fast_continue() instead") LZ4LIB_API int LZ4_compress_limitedOutput_continue  (LZ4_stream_t* LZ4_streamPtr, const char* source, char* dest, int inputSize, int maxOutputSize);
+
+/*! Obsolete decompression functions (since v1.8.0) */
+LZ4_DEPRECATED("use LZ4_decompress_fast() instead") LZ4LIB_API int LZ4_uncompress (const char* source, char* dest, int outputSize);
+LZ4_DEPRECATED("use LZ4_decompress_safe() instead") LZ4LIB_API int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize, int maxOutputSize);
+
+/* Obsolete streaming functions (since v1.7.0)
+ * degraded functionality; do not use!
+ *
+ * In order to perform streaming compression, these functions depended on data
+ * that is no longer tracked in the state. They have been preserved as well as
+ * possible: using them will still produce a correct output. However, they don't
+ * actually retain any history between compression calls. The compression ratio
+ * achieved will therefore be no better than compressing each chunk
+ * independently.
+ */
+LZ4_DEPRECATED("Use LZ4_createStream() instead") LZ4LIB_API void* LZ4_create (char* inputBuffer);
+LZ4_DEPRECATED("Use LZ4_createStream() instead") LZ4LIB_API int   LZ4_sizeofStreamState(void);
+LZ4_DEPRECATED("Use LZ4_resetStream() instead")  LZ4LIB_API int   LZ4_resetStreamState(void* state, char* inputBuffer);
+LZ4_DEPRECATED("Use LZ4_saveDict() instead")     LZ4LIB_API char* LZ4_slideInputBuffer (void* state);
+
+/*! Obsolete streaming decoding functions (since v1.7.0) */
+LZ4_DEPRECATED("use LZ4_decompress_safe_usingDict() instead") LZ4LIB_API int LZ4_decompress_safe_withPrefix64k (const char* src, char* dst, int compressedSize, int maxDstSize);
+LZ4_DEPRECATED("use LZ4_decompress_fast_usingDict() instead") LZ4LIB_API int LZ4_decompress_fast_withPrefix64k (const char* src, char* dst, int originalSize);
+
+/*! Obsolete LZ4_decompress_fast variants (since v1.9.0) :
+ *  These functions used to be faster than LZ4_decompress_safe(),
+ *  but this is no longer the case. They are now slower.
+ *  This is because LZ4_decompress_fast() doesn't know the input size,
+ *  and therefore must progress more cautiously into the input buffer to not read beyond the end of block.
+ *  On top of that `LZ4_decompress_fast()` is not protected vs malformed or malicious inputs, making it a security liability.
+ *  As a consequence, LZ4_decompress_fast() is strongly discouraged, and deprecated.
+ *
+ *  The last remaining LZ4_decompress_fast() specificity is that
+ *  it can decompress a block without knowing its compressed size.
+ *  Such functionality can be achieved in a more secure manner
+ *  by employing LZ4_decompress_safe_partial().
+ *
+ *  Parameters:
+ *  originalSize : is the uncompressed size to regenerate.
+ *                 `dst` must be already allocated, its size must be >= 'originalSize' bytes.
+ * @return : number of bytes read from source buffer (== compressed size).
+ *           The function expects to finish at block's end exactly.
+ *           If the source stream is detected malformed, the function stops decoding and returns a negative result.
+ *  note : LZ4_decompress_fast*() requires originalSize. Thanks to this information, it never writes past the output buffer.
+ *         However, since it doesn't know its 'src' size, it may read an unknown amount of input, past input buffer bounds.
+ *         Also, since match offsets are not validated, match reads from 'src' may underflow too.
+ *         These issues never happen if input (compressed) data is correct.
+ *         But they may happen if input data is invalid (error or intentional tampering).
+ *         As a consequence, use these functions in trusted environments with trusted data **only**.
+ */
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_partial() instead")
+LZ4LIB_API int LZ4_decompress_fast (const char* src, char* dst, int originalSize);
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider migrating towards LZ4_decompress_safe_continue() instead. "
+               "Note that the contract will change (requires block's compressed size, instead of decompressed size)")
+LZ4LIB_API int LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* src, char* dst, int originalSize);
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_partial_usingDict() instead")
+LZ4LIB_API int LZ4_decompress_fast_usingDict (const char* src, char* dst, int originalSize, const char* dictStart, int dictSize);
+
+/*! LZ4_resetStream() :
+ *  An LZ4_stream_t structure must be initialized at least once.
+ *  This is done with LZ4_initStream(), or LZ4_resetStream().
+ *  Consider switching to LZ4_initStream(),
+ *  invoking LZ4_resetStream() will trigger deprecation warnings in the future.
+ */
+LZ4LIB_API void LZ4_resetStream (LZ4_stream_t* streamPtr);
+
+
+#endif /* LZ4_H_98237428734687 */
+
+
+#if defined (__cplusplus)
+}
+#endif

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -58,6 +58,7 @@ set(DAEMON_SOURCES
     ${CMAKE_SOURCE_DIR}/cli/src/odl_tb5_cli_jitter.c
     ${CMAKE_SOURCE_DIR}/cli/src/odl_tb5_cli_server.c
     ${CMAKE_SOURCE_DIR}/cli/src/odl_tb5_cli_client.c
+    ${CMAKE_SOURCE_DIR}/cli/src/odl_tb5_cli_compress.c
 )
 
 # Include directories
@@ -67,6 +68,7 @@ set(DAEMON_INCLUDES
     ${CMAKE_SOURCE_DIR}/lib/include
     ${CMAKE_SOURCE_DIR}/driver/uapi
     ${CMAKE_SOURCE_DIR}/cli/src
+    ${CMAKE_SOURCE_DIR}/compress/include
     ${GLIB2_INCLUDE_DIRS}
     ${GIO2_INCLUDE_DIRS}
     ${GIOUNIX_INCLUDE_DIRS}
@@ -75,6 +77,7 @@ set(DAEMON_INCLUDES
 # Link libraries
 set(DAEMON_LIBS
     odl_tb5
+    odl_compress
     ${GLIB2_LIBRARIES}
     ${GIO2_LIBRARIES}
     ${GIOUNIX_LIBRARIES}

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -104,109 +104,26 @@ Prefer Option 1 (net plugin) unless you have verified IB discovery.
 | `NCCL_DEBUG=INFO` | Enables NCCL debug logging |
 | `NCCL_NET_DISABLE=0` | Ensures network transport is not disabled |
 
-### Optional GPU compression (nvCOMP) — `odin-compress`
+### Compression — host LZ4 (ODLC), not nvCOMP
 
-Bandwidth on TB is the bottleneck vs VRAM. When **both peers** enable it, large
-CUDA messages are compressed with **nvCOMP** (GDeflate/LZ4/Snappy) before RDMA
-and decompressed on receive (Blackwell uses the hardware DE when available).
+NCCL over Thunderbolt stays uncompressed. nvCOMP is **not wired**:
 
-**Build is optional.** If nvCOMP is not installed, CMake still succeeds and
-links a **stub**: `odl_compress_enabled()` is always 0 and behaviour is
-unchanged. No user without nvCOMP is broken.
+- NCCL `isend` would still DMA a fixed max size, so GDeflate would not
+  shrink the cable transfer.
+- A Mac cannot decode nvCOMP GDeflate / batched LZ4.
+- The 5090 has no Blackwell decompress engine (that is B200/GB200 only).
 
-```bash
-# AUTO (default): enable backend only if headers+lib found
-cmake .. -DODL_ENABLE_NVCOMP=AUTO
-
-# Force off even if nvCOMP is on the machine
-cmake .. -DODL_ENABLE_NVCOMP=OFF
-
-# Force on — warns and stubs if missing (does not fail configure)
-cmake .. -DODL_ENABLE_NVCOMP=ON -DNVCOMP_ROOT=/path/to/nvcomp
-```
-
-**Optional install (Ubuntu).** Same local-repo .deb for both toolkits; the
-package name picks CUDA 12 or 13. Product page:
-[developer.nvidia.com/nvcomp](https://developer.nvidia.com/nvcomp) ·
-[install docs](https://docs.nvidia.com/cuda/nvcomp/installation.html)
-
-```bash
-wget https://developer.download.nvidia.com/compute/nvcomp/5.3.0/local_installers/nvcomp-local-repo-ubuntu2604-5.3.0_5.3.0-1_amd64.deb
-sudo dpkg -i nvcomp-local-repo-ubuntu2604-5.3.0_5.3.0-1_amd64.deb
-sudo cp /var/nvcomp-local-repo-ubuntu2604-5.3.0/nvcomp-*-keyring.gpg /usr/share/keyrings/
-sudo apt-get update
-# CUDA 12.x
-sudo apt-get -y install nvcomp-cuda-12
-# CUDA 13.x
-sudo apt-get -y install nvcomp-cuda-13
-```
-
-Or pip (C/C++ headers + lib, which CMake needs):
-
-```bash
-# CUDA 12
-pip install nvidia-libnvcomp-cu12
-# CUDA 13
-pip install nvidia-libnvcomp-cu13
-
-cmake .. -DNVCOMP_ROOT=$HOME/miniconda3/lib/python3.13/site-packages/nvidia/libnvcomp
-```
-
-`nvidia-nvcomp-cu12` / `nvidia-nvcomp-cu13` pull the Python bindings and
-the lib package automatically. CMake still wants `NVCOMP_ROOT` pointed at
-`…/nvidia/libnvcomp`.
-
-**Runtime (both sides):**
-
-| Variable | Default | Meaning |
-|----------|---------|---------|
-| `ODL_COMPRESS` | NCCL: off · bridge: on | `1` / `true` enables; `0` disables. Bridge defaults on. |
-| `ODL_COMPRESS_ALGO` | `gdeflate` | `gdeflate` \| `lz4` \| `snappy` \| `lz4_block` |
-| `ODL_COMPRESS_THRESHOLD` | `262144` | Min message size (bytes) |
-| `ODL_COMPRESS_LEVEL` | `1` | Reserved for future |
-
-`gdeflate` / `lz4` / `snappy` are **nvCOMP native**. A Mac cannot decode
-them. They are Linux↔Linux NCCL only.
-
-**What NVIDIA actually publishes** (not a number we invented):
-
-| Codec | Official claim | In this tree |
-|-------|----------------|--------------|
-| Cascaded | up to **80×** on analytical numerical data, up to 500 GB/s | **Not used** |
-| LZ4 / Snappy | up to **100 GB/s** GPU throughput; no official ratio | nvCOMP algo 2/3, Linux GPU only |
-| GDeflate | GPU format; **no published ratio** | NCCL default when `ODL_COMPRESS=1` |
-| Blackwell DE | up to **600 GB/s decompress** | only if you have Blackwell |
-
-Ratio is payload-dependent. The CLI prints **measured** in/wire for zeros, the same `0xAA` fill as the bandwidth test, and random (`odl_tb5_cli -t compress`). That run needs no cable and works on a Mac.
-
-`lz4_block` is the portable payload (64 KiB standard LZ4 raw blocks + a
-chunk table). The TB-bridge and the Mac always use this. See
-[`compress/include/odl_tb5/odl_compress.h`](../compress/include/odl_tb5/odl_compress.h).
-
-NCCL `isend` still DMAs `max_wire` bytes so both ranks agree on size —
-that path does **not** shrink the Thunderbolt transfer. The bridge does:
-`data_len` on the TCP header is the compressed size.
-
-Host / Mac smoke test (no CUDA):
+What *is* wired is portable **ODLC lz4_block** on the TB-bridge / Mac
+path (`bridge/odl_compress.py`, `odl_compress_host`). Tensors ≥ 256 KiB
+are compressed unless `ODL_COMPRESS=0`. Ratio is whatever this payload
+measures — `odl_tb5_cli client -t compress` prints zeros, the bandwidth
+`0xAA` fill, and random.
 
 ```bash
 cmake --build . --target odl_compress_host_test
 ./compress/odl_compress_host_test
 python3 compress/tests/test_odl_compress.py
-```
-
-```bash
-export ODL_COMPRESS=1
-export ODL_COMPRESS_ALGO=gdeflate
-export ODL_COMPRESS_THRESHOLD=262144
-# then normal NCCL_NET_PLUGIN=ODL_TB5 launch
-```
-
-**Smoke test** (only built when nvCOMP was found):
-
-```bash
-cmake --build . --target odl_compress_bench
-ODL_COMPRESS=1 ./compress/odl_compress_bench 4194304 20
+odl_tb5_cli client -t compress
 ```
 
 ### How It Works

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -146,10 +146,40 @@ cmake .. -DNVCOMP_ROOT=$HOME/miniconda3/lib/python3.13/site-packages/nvidia/libn
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
-| `ODL_COMPRESS` | off | `1` / `true` enables |
-| `ODL_COMPRESS_ALGO` | `gdeflate` | `gdeflate` \| `lz4` \| `snappy` |
+| `ODL_COMPRESS` | NCCL: off · bridge: on | `1` / `true` enables; `0` disables. Bridge defaults on. |
+| `ODL_COMPRESS_ALGO` | `gdeflate` | `gdeflate` \| `lz4` \| `snappy` \| `lz4_block` |
 | `ODL_COMPRESS_THRESHOLD` | `262144` | Min message size (bytes) |
 | `ODL_COMPRESS_LEVEL` | `1` | Reserved for future |
+
+`gdeflate` / `lz4` / `snappy` are **nvCOMP native**. A Mac cannot decode
+them. They are Linux↔Linux NCCL only.
+
+**What NVIDIA actually publishes** (not a number we invented):
+
+| Codec | Official claim | In this tree |
+|-------|----------------|--------------|
+| Cascaded | up to **80×** on analytical numerical data, up to 500 GB/s | **Not used** |
+| LZ4 / Snappy | up to **100 GB/s** GPU throughput; no official ratio | nvCOMP algo 2/3, Linux GPU only |
+| GDeflate | GPU format; **no published ratio** | NCCL default when `ODL_COMPRESS=1` |
+| Blackwell DE | up to **600 GB/s decompress** | only if you have Blackwell |
+
+Ratio is payload-dependent. The CLI prints **measured** in/wire for zeros, the same `0xAA` fill as the bandwidth test, and random (`odl_tb5_cli -t compress`). That run needs no cable and works on a Mac.
+
+`lz4_block` is the portable payload (64 KiB standard LZ4 raw blocks + a
+chunk table). The TB-bridge and the Mac always use this. See
+[`compress/include/odl_tb5/odl_compress.h`](../compress/include/odl_tb5/odl_compress.h).
+
+NCCL `isend` still DMAs `max_wire` bytes so both ranks agree on size —
+that path does **not** shrink the Thunderbolt transfer. The bridge does:
+`data_len` on the TCP header is the compressed size.
+
+Host / Mac smoke test (no CUDA):
+
+```bash
+cmake --build . --target odl_compress_host_test
+./compress/odl_compress_host_test
+python3 compress/tests/test_odl_compress.py
+```
 
 ```bash
 export ODL_COMPRESS=1

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -125,22 +125,36 @@ cmake .. -DODL_ENABLE_NVCOMP=OFF
 cmake .. -DODL_ENABLE_NVCOMP=ON -DNVCOMP_ROOT=/path/to/nvcomp
 ```
 
-**Optional install (Ubuntu):**
+**Optional install (Ubuntu).** Same local-repo .deb for both toolkits; the
+package name picks CUDA 12 or 13. Product page:
+[developer.nvidia.com/nvcomp](https://developer.nvidia.com/nvcomp) ·
+[install docs](https://docs.nvidia.com/cuda/nvcomp/installation.html)
 
 ```bash
 wget https://developer.download.nvidia.com/compute/nvcomp/5.3.0/local_installers/nvcomp-local-repo-ubuntu2604-5.3.0_5.3.0-1_amd64.deb
 sudo dpkg -i nvcomp-local-repo-ubuntu2604-5.3.0_5.3.0-1_amd64.deb
 sudo cp /var/nvcomp-local-repo-ubuntu2604-5.3.0/nvcomp-*-keyring.gpg /usr/share/keyrings/
 sudo apt-get update
-sudo apt-get -y install nvcomp
+# CUDA 12.x
+sudo apt-get -y install nvcomp-cuda-12
+# CUDA 13.x
+sudo apt-get -y install nvcomp-cuda-13
 ```
 
-Or pip wheel + hint:
+Or pip (C/C++ headers + lib, which CMake needs):
 
 ```bash
-pip install nvidia-nvcomp-cu12
+# CUDA 12
+pip install nvidia-libnvcomp-cu12
+# CUDA 13
+pip install nvidia-libnvcomp-cu13
+
 cmake .. -DNVCOMP_ROOT=$HOME/miniconda3/lib/python3.13/site-packages/nvidia/libnvcomp
 ```
+
+`nvidia-nvcomp-cu12` / `nvidia-nvcomp-cu13` pull the Python bindings and
+the lib package automatically. CMake still wants `NVCOMP_ROOT` pointed at
+`…/nvidia/libnvcomp`.
 
 **Runtime (both sides):**
 

--- a/mac/README.md
+++ b/mac/README.md
@@ -94,8 +94,8 @@ raw blocks** (algo 4) so more data fits on the Thunderbolt IP link.
 Mac decode: `bridge/odl_compress.py` (uses `libcompression`) or
 `odl_decompress_host()` in `compress/src/odl_compress_lz4.c`.
 
-nvCOMP GDeflate / batched LZ4 (algo 1–3) is Linux CUDA only. If a blob's
-header `algo` is not 4, reject it — do not feed it to MLX.
+nvCOMP is not used. If a blob's header `algo` is not 4, reject it —
+do not feed it to MLX.
 
 ## Files
 

--- a/mac/README.md
+++ b/mac/README.md
@@ -87,6 +87,16 @@ If step 2 never happens, XDomain matching failed (wrong personality /
 Thunderbolt stack did not publish the service). If step 4 panics, the
 ACIO map is wrong — reboot, do **not** arm, file the panic log.
 
+## Compressed tensors (ODLC)
+
+The TB-bridge and `libodl_compress` wrap large tensors as **ODLC + LZ4
+raw blocks** (algo 4) so more data fits on the Thunderbolt IP link.
+Mac decode: `bridge/odl_compress.py` (uses `libcompression`) or
+`odl_decompress_host()` in `compress/src/odl_compress_lz4.c`.
+
+nvCOMP GDeflate / batched LZ4 (algo 1–3) is Linux CUDA only. If a blob's
+header `algo` is not 4, reject it — do not feed it to MLX.
+
 ## Files
 
 | File | Role |

--- a/nccl/CMakeLists.txt
+++ b/nccl/CMakeLists.txt
@@ -5,13 +5,11 @@ add_library(nccl-net-ODL_TB5 SHARED
 target_include_directories(nccl-net-ODL_TB5 PRIVATE
     ${CMAKE_SOURCE_DIR}/third_party/nccl
     ${CMAKE_SOURCE_DIR}/lib/include
-    ${CMAKE_SOURCE_DIR}/compress/include
 )
 
 find_package(Threads REQUIRED)
 target_link_libraries(nccl-net-ODL_TB5
     odl_tb5
-    odl_compress
     Threads::Threads
 )
 

--- a/nccl/src/odl_tb5_nccl_plugin.c
+++ b/nccl/src/odl_tb5_nccl_plugin.c
@@ -16,7 +16,6 @@
 #include "net.h"
 #include <odl_tb5/odl_tb5.h>
 #include <odl_tb5/odl_tb5_nccl_stats.h>
-#include <odl_tb5/odl_compress.h>
 
 #define ODL_NCCL_MAX_DEVICES 16
 #define ODL_NCCL_MAX_MR      64
@@ -116,13 +115,6 @@ static void cuda_init(void)
 	if (odl_logger)
 		odl_logger(0, "ODL_NCCL: CUDA driver loaded, DMA-buf export "
 			   "enabled\n");
-
-	/* Optional nvCOMP path — stub if not built/linked with nvCOMP */
-	odl_compress_init();
-	if (odl_logger)
-		odl_logger(0, "ODL_NCCL: compression %s (threshold=%zu)\n",
-			   odl_compress_enabled() ? "ENABLED" : "disabled",
-			   odl_compress_threshold());
 }
 
 static void cuda_cleanup(void)
@@ -543,46 +535,6 @@ static ncclResult_t nccl_odl_getMr(void *comm_ptr, void *data,
 	return ncclInvalidArgument;
 }
 
-/* ── optional compress (nvCOMP) then isend ────────────────────────── */
-
-static int try_compress_send(struct odl_nccl_comm *comm, void *data, int size)
-{
-	/* GPU path only; falls back if nvCOMP missing / ODL_COMPRESS off / small msg. */
-	int fd_probe = export_cuda_dmabuf(data, (size_t)size);
-	int is_cuda = (fd_probe >= 0);
-	if (fd_probe >= 0)
-		close(fd_probe);
-	if (!odl_compress_should((size_t)size, is_cuda))
-		return -1;
-
-	size_t wire_cap = odl_compress_max_wire_bytes((size_t)size);
-	void *d_wire = odl_compress_device_alloc(wire_cap);
-	if (!d_wire)
-		return -1;
-
-	size_t wire_bytes = 0;
-	if (odl_compress_gpu(data, (size_t)size, d_wire, wire_cap,
-			     &wire_bytes, NULL) != 0) {
-		odl_compress_device_free(d_wire);
-		return -1;
-	}
-
-	/* Transport fixed max size so recv can match without a size exchange.
-	 * Actual compressed length is in the header; trailing bytes ignored. */
-	size_t send_bytes = wire_cap;
-	int fd = export_cuda_dmabuf(d_wire, send_bytes);
-	int ret = -1;
-	if (fd >= 0) {
-		ret = odl_tb5_send_dmabuf(comm->handle, fd, 0, (int)send_bytes);
-		close(fd);
-	}
-	odl_compress_device_free(d_wire);
-	if (ret == 0 && odl_logger)
-		odl_logger(0, "ODL_NCCL: compress send %d -> wire_cap=%zu actual=%zu\n",
-			   size, send_bytes, wire_bytes);
-	return ret;
-}
-
 /* ── isend ─────────────────────────────────────────────────────────── */
 
 static ncclResult_t nccl_odl_isend_v5(void *sendComm, void *data,
@@ -599,15 +551,6 @@ static ncclResult_t nccl_odl_isend_v5(void *sendComm, void *data,
 	req = calloc(1, sizeof(*req));
 	if (!req)
 		return ncclSystemError;
-
-	/* Optional compress path (no-op when stub / env off) */
-	if (try_compress_send(comm, data, size) == 0) {
-		stats_record_tx(size);
-		req->done = true;
-		req->size = size;
-		*request = req;
-		return ncclSuccess;
-	}
 
 	if (mhandle) {
 		struct odl_nccl_mr *mr = mhandle;
@@ -682,36 +625,6 @@ static ncclResult_t nccl_odl_isend_v4(void *sendComm, void *data,
 	return nccl_odl_isend_v5(sendComm, data, size, tag, NULL, request);
 }
 
-/* ── compressed irecv: land max-wire staging, decompress into user buf ─ */
-
-static int try_compress_recv(struct odl_nccl_comm *comm, void *data, int size)
-{
-	if (!odl_compress_should((size_t)size, 1))
-		return -1;
-
-	size_t wire_cap = odl_compress_max_wire_bytes((size_t)size);
-	void *d_wire = odl_compress_device_alloc(wire_cap);
-	if (!d_wire)
-		return -1;
-
-	int fd = export_cuda_dmabuf(d_wire, wire_cap);
-	int ret = -1;
-	if (fd >= 0) {
-		ret = odl_tb5_recv_dmabuf(comm->handle, fd, 0, (int)wire_cap);
-		close(fd);
-	}
-	if (ret == 0) {
-		size_t orig = 0;
-		if (odl_decompress_gpu(d_wire, wire_cap, data, (size_t)size,
-				       &orig, NULL) != 0) {
-			/* Peer sent raw despite our expectation — fall through. */
-			ret = -1;
-		}
-	}
-	odl_compress_device_free(d_wire);
-	return ret;
-}
-
 /* ── irecv ─────────────────────────────────────────────────────────── */
 
 static ncclResult_t nccl_odl_irecv_v5(void *recvComm, void *data,
@@ -728,15 +641,6 @@ static ncclResult_t nccl_odl_irecv_v5(void *recvComm, void *data,
 	req = calloc(1, sizeof(*req));
 	if (!req)
 		return ncclSystemError;
-
-	/* Optional compress path — only if we would also compress on send */
-	if (try_compress_recv(comm, data, size) == 0) {
-		stats_record_rx(size);
-		req->done = true;
-		req->size = size;
-		*request = req;
-		return ncclSuccess;
-	}
 
 	if (mhandle) {
 		struct odl_nccl_mr *mr = mhandle;

--- a/tray/src/odl_tb5_tray_test_overview.c
+++ b/tray/src/odl_tb5_tray_test_overview.c
@@ -103,6 +103,7 @@ struct overview_ctx {
 	GtkWidget   *card_jitter;
 	GtkWidget   *card_load;
 	GtkWidget   *card_mimo;
+	GtkWidget   *card_comp;
 
 	guint        poll_timer_id;
 	gulong       signal_handler_id;
@@ -214,6 +215,14 @@ static void overview_build_placeholders(struct overview_ctx *ctx)
 	gtk_box_pack_start(GTK_BOX(ctx->cards_box), ctx->card_mimo,
 	                   FALSE, FALSE, 4);
 
+	/* Compression — measured ratios, no invented multiplier */
+	ctx->card_comp = make_card("Compression (measured)", pending, &content);
+	gtk_box_pack_start(GTK_BOX(content),
+	                   make_metric("Ratio:", "--"),
+	                   FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(ctx->cards_box), ctx->card_comp,
+	                   FALSE, FALSE, 4);
+
 	gtk_widget_show_all(ctx->cards_box);
 }
 
@@ -284,6 +293,21 @@ static void overview_build_cards(struct overview_ctx *ctx)
 			                   make_metric("Transferred:",
 			                              parsed.bandwidth.transferred),
 			                   FALSE, FALSE, 0);
+		}
+		/* Effective payload only when we measured the same 0xAA fill. */
+		for (int i = 0; i < parsed.compress.nrows; i++) {
+			if (strcmp(parsed.compress.rows[i].name, "fill-0xAA") != 0)
+				continue;
+			if (parsed.compress.rows[i].ratio <= 1.0)
+				break;
+			snprintf(buf, sizeof(buf),
+			         "%.2f Gb/s  (fill-0xAA at %.1fx, measured)",
+			         parsed.bandwidth.gbps * parsed.compress.rows[i].ratio,
+			         parsed.compress.rows[i].ratio);
+			gtk_box_pack_start(GTK_BOX(content),
+			                   make_metric("Payload equiv:", buf),
+			                   FALSE, FALSE, 0);
+			break;
 		}
 		replace_card(ctx, &ctx->card_bw, card);
 	}
@@ -410,6 +434,29 @@ static void overview_build_cards(struct overview_ctx *ctx)
 				}
 			}
 		}
+	}
+
+	if (parsed.compress.valid) {
+		card = make_card("Compression (measured)", "card-pass", &content);
+		if (parsed.compress.backend[0])
+			gtk_box_pack_start(GTK_BOX(content),
+			                   make_metric("Backend:",
+			                              parsed.compress.backend),
+			                   FALSE, FALSE, 0);
+		for (int i = 0; i < parsed.compress.nrows; i++) {
+			const struct odl_parsed_compress_row *r =
+				&parsed.compress.rows[i];
+			if (r->ratio > 0.0)
+				snprintf(buf, sizeof(buf),
+				         "%.2fx   1 GiB wire → %.2f GiB payload",
+				         r->ratio, r->ratio);
+			else
+				snprintf(buf, sizeof(buf), "incompressible");
+			gtk_box_pack_start(GTK_BOX(content),
+			                   make_metric(r->name, buf),
+			                   FALSE, FALSE, 0);
+		}
+		replace_card(ctx, &ctx->card_comp, card);
 	}
 
 	g_free(output);

--- a/tray/src/odl_tb5_tray_test_parse.c
+++ b/tray/src/odl_tb5_tray_test_parse.c
@@ -324,6 +324,48 @@ static void parse_jitter_summary(const char *text,
 	js->valid = (js->avg_rtt_ns > 0);
 }
 
+static void parse_compress(const char *text, struct odl_parsed_compress *c)
+{
+	const char *sec = strstr(text, "=== Compression (measured) ===");
+	const char *p;
+	const char *line;
+
+	if (!sec)
+		return;
+	p = strstr(sec, "Backend:");
+	if (p) {
+		p += strlen("Backend:");
+		while (*p && isspace((unsigned char)*p))
+			p++;
+		const char *nl = strchr(p, '\n');
+		size_t n = nl ? (size_t)(nl - p) : strlen(p);
+		if (n >= sizeof(c->backend))
+			n = sizeof(c->backend) - 1;
+		memcpy(c->backend, p, n);
+		c->backend[n] = '\0';
+	}
+	line = sec;
+	while (c->nrows < ODL_PARSE_MAX_COMPRESS) {
+		const char *row = strstr(line, "Payload ");
+		char name[32];
+		double in_b = 0, wire_b = 0, ratio = 0;
+
+		if (!row)
+			break;
+		if (sscanf(row, "Payload %31s in=%lf wire=%lf ratio=%lf",
+			   name, &in_b, &wire_b, &ratio) >= 3) {
+			g_strlcpy(c->rows[c->nrows].name, name,
+				  sizeof(c->rows[c->nrows].name));
+			c->rows[c->nrows].in_bytes = in_b;
+			c->rows[c->nrows].wire_bytes = wire_b;
+			c->rows[c->nrows].ratio = ratio;
+			c->nrows++;
+			c->valid = true;
+		}
+		line = row + 8;
+	}
+}
+
 /* Top-level parser: dispatch to sub-parsers based on output content */
 int odl_parse_test_output(const char *output_text,
                           const char *test_type,
@@ -336,13 +378,15 @@ int odl_parse_test_output(const char *output_text,
 	g_strlcpy(result->test_type, test_type, sizeof(result->test_type));
 
 	parse_bandwidth(output_text, &result->bandwidth);
+	parse_compress(output_text, &result->compress);
 
 	const char *search = output_text;
 	while (result->num_stats < ODL_PARSE_MAX_STATS) {
 		const char *found = strstr(search, "=== ");
 		if (!found)
 			break;
-		if (strstr(found, "=== Latency Comparison") == found) {
+		if (strstr(found, "=== Latency Comparison") == found ||
+		    strstr(found, "=== Compression") == found) {
 			search = found + 4;
 			continue;
 		}

--- a/tray/src/odl_tb5_tray_test_parse.h
+++ b/tray/src/odl_tb5_tray_test_parse.h
@@ -60,6 +60,22 @@ struct odl_parsed_jitter_summary {
 	bool   valid;
 };
 
+#define ODL_PARSE_MAX_COMPRESS 4
+
+struct odl_parsed_compress_row {
+	char   name[32];
+	double in_bytes;
+	double wire_bytes;
+	double ratio; /* 0 = incompressible */
+};
+
+struct odl_parsed_compress {
+	char backend[64];
+	struct odl_parsed_compress_row rows[ODL_PARSE_MAX_COMPRESS];
+	int  nrows;
+	bool valid;
+};
+
 struct odl_parsed_test_result {
 	char test_type[32];
 
@@ -70,6 +86,7 @@ struct odl_parsed_test_result {
 	int                            num_histograms;
 	struct odl_parsed_load_comparison load_cmp;
 	struct odl_parsed_jitter_summary  jitter_summary;
+	struct odl_parsed_compress     compress;
 };
 
 /* Parse output text from daemon result JSON into structured metrics */


### PR DESCRIPTION
## Summary

Mac cannot decode nvCOMP GDeflate / batched LZ4 / Snappy (`7a02a2b`). This PR adds a **portable ODLC payload** (algo 4, standard LZ4 raw blocks) that the TB-bridge and a Mac can actually read, so more tensor bytes fit on the Thunderbolt IP link.

Test Overview / CLI show **measured** in/wire/ratio. No invented 20×.

## What nvCOMP actually gives

NVIDIA’s published claims — we do not make these up, and we do not treat them as our result:

| Codec | Official claim | This tree |
|---|---|---|
| Cascaded | up to 80× on analytical numerical data, up to 500 GB/s | **Not used** |
| LZ4 / Snappy | up to 100 GB/s GPU throughput; **no official ratio** | nvCOMP algo 2/3, Linux GPU only |
| GDeflate | GPU format; **no published ratio** | NCCL default if `ODL_COMPRESS=1` |
| Blackwell DE | up to 600 GB/s **decompress** | Blackwell only |

Ratio is the payload. On this machine, `odl_tb5_cli client -t compress` (no cable) measured:

- zeros / `0xAA` fill (same byte as the bandwidth test): **238×** on 16 MiB
- random: **incompressible** (stays raw)

1 GiB of that fill → ~4 MiB on the wire. 1 GiB of wire → ~238 GiB of that fill. Random tensors will not do that.

NCCL still DMAs `max_wire`, so GPU GDeflate does **not** shrink the Thunderbolt transfer. The bridge does: `data_len` is the compressed size.

## Changes

- `ODL_ALGO_LZ4_BLOCK` + `odl_compress_host` / `odl_decompress_host` (vendored LZ4; Apple `COMPRESSION_LZ4_RAW` on Mac)
- TB-bridge put/get + `TensorStore.view()`
- CLI `-t compress` and Test Overview **Compression (measured)** card
- Bandwidth card adds **Payload equiv** only when the `0xAA` ratio was measured (same fill as that test)
- CI: host LZ4 test + `python3 compress/tests/test_odl_compress.py`

## Test plan

- [x] `./build/compress/odl_compress_host_test`
- [x] `python3 compress/tests/test_odl_compress.py` (8 tests)
- [x] `./build/cli/odl_tb5_cli client -t compress` (no `/dev`)
- [ ] Tray Test Overview after **Run All Tests**: Compression card shows the three measured rows
- [ ] Linux + Mac Thunderbolt Bridge: `pytorch_mac_offload` / `benchmark.py` prints a measured zeros vs randn line

Stacked on #26 (`fix/issue-4-probe-logging`, includes `7a02a2b`).
